### PR TITLE
Fixed cnn scenario to find top story element consistently.

### DIFF
--- a/TestingPower/Program.cs
+++ b/TestingPower/Program.cs
@@ -65,9 +65,16 @@ namespace TestingPower
                         // When we get control back, we sleep for the remaining time for the scenario. This ensures
                         // the total time for a scenario is always the same
                         var runTime = watch.Elapsed.Subtract(startTime);
+                        
                         // We even allow the exception to fall through and break the run if we pass a negative number
                         // in here (meaning the scenario took longer to return than the total time it expected)
-                        Thread.Sleep(TimeSpan.FromSeconds(scenario.Duration).Subtract(runTime));
+                        var timeLeft = TimeSpan.FromSeconds(scenario.Duration).Subtract(runTime);
+                        
+                        if (timeLeft < TimeSpan.FromSeconds(0))
+                        {                            
+                            throw new Exception("Scenario ran longer than expected! The browser ran slower than expected or the duration of the scenario is too short.");
+                        }
+                        Thread.Sleep(timeLeft);
                     }
                 }
 
@@ -94,6 +101,7 @@ namespace TestingPower
             AddScenario(new AmazonSearch());
             AddScenario(new GoogleSearch());
             AddScenario(new CnnTopStory());
+            AddScenario(new TechRadarSurfacePro4Review());
         }
 
         private static void AddScenario(Scenario scenario)
@@ -141,6 +149,8 @@ namespace TestingPower
                         {
                             // Specify the "official" runs, including order
                             scenarios.Add(possibleScenarios["youtube"]);
+                            scenarios.Add(possibleScenarios["cnn"]);
+                            scenarios.Add(possibleScenarios["techRadar"]);
                             scenarios.Add(possibleScenarios["amazon"]);
                             // Reddit and amazon combined hang Opera.
                             // Re-ordering them causes the other to crash.
@@ -150,6 +160,7 @@ namespace TestingPower
                             scenarios.Add(possibleScenarios["google"]);
                             scenarios.Add(possibleScenarios["gmail"]);
                             scenarios.Add(possibleScenarios["wikipedia"]);
+
                             break;
                         }
 

--- a/TestingPower/Scenarios/CnnTopStory.cs
+++ b/TestingPower/Scenarios/CnnTopStory.cs
@@ -11,7 +11,9 @@ namespace TestingPower
         public CnnTopStory()
         {
             Name = "cnn";
-            Duration = 60;
+
+            // Using 80 as sometimes Chrome takes just over 70 seconds to run            
+            Duration = 80;
         }
 
         public override void Run(RemoteWebDriver driver, string browser, List<UserInfo> logins)
@@ -22,14 +24,13 @@ namespace TestingPower
             Thread.Sleep(5000); 
 
             // Get the element that contains the headline story
-            var headlineElement = driver.FindElementByClassName("zn-banner");
-            var aRefElement = headlineElement.FindElement(By.TagName("a"));
+            var headlineElement = driver.FindElementByClassName("js-screaming-banner");
 
-            // Get focus on the headline story link 
-            aRefElement.SendKeys(String.Empty);
+            // Get focus on the headline story link
+            headlineElement.SendKeys(String.Empty);
 
             // Open the link to the headline story
-            aRefElement.SendKeys(Keys.Enter);
+            headlineElement.SendKeys(Keys.Enter);
 
             // And let that load
             Thread.Sleep(2 * 1000);

--- a/TestingPower/Scenarios/TechRadarSurfacePro4Review.cs
+++ b/TestingPower/Scenarios/TechRadarSurfacePro4Review.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium;
+using System.Threading;
+
+namespace TestingPower
+{
+    class TechRadarSurfacePro4Review : Scenario
+    {
+        public TechRadarSurfacePro4Review()
+        {
+            Name = "techRadar";
+            Duration = 60;
+        }
+
+        public override void Run(RemoteWebDriver driver, string browser, List<UserInfo> logins)
+        {
+            // Navigate to the Surface Pro 4 review on TechRadar.
+            driver.Navigate().GoToUrl("http://www.techradar.com/us/reviews/pc-mac/tablets/microsoft-surface-pro-4-1290285/review");
+
+            // Give it more than enough time to load
+            Thread.Sleep(5000);
+
+            // Scroll down multiple times
+            Program.scrollPage(10);
+        }
+    }
+}

--- a/TestingPower/TestingPower.csproj
+++ b/TestingPower/TestingPower.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Scenarios\Msnbc.cs" />
     <Compile Include="Scenarios\OutlookViewEmails.cs" />
     <Compile Include="Scenarios\RedditSearchSubreddit.cs" />
+    <Compile Include="Scenarios\TechRadarSurfacePro4Review.cs" />
     <Compile Include="Scenarios\WikipediaUnitedStates.cs" />
     <Compile Include="Scenarios\YoutubeWatchVideo.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
Added TechRadar scenario

Added error check to the scenario remaining time duration calculation.

Added cnn and techRadar scenarios to the 'all' scenario
