### PR TITLE
Style changes. Ran the dotnet codeformatter tool with /nocopyright to…

### DIFF
--- a/TestingPower/AutomateWPR.cs
+++ b/TestingPower/AutomateWPR.cs
@@ -25,32 +25,33 @@
 //
 //--------------------------------------------------------------
 
-﻿using System;
+using System;
 using System.Diagnostics;
 
-namespace TestingPower {
-   /// <summary>
-   /// Provides Windows tracing controls using Windows Performance Recorder (WPR).
-   /// By default AutomateWPR assumes WPR has been installed on the test machine as part of the Windows Performance Toolkit.
-   /// Other WPR.exe can optionally be specified by passing the path to the WPR.exe location during instantiation.
-   ///
-   /// NOTE: TestingPower.exe must be run elevated in order to allow control of WPR.exe.
-   /// 
-   /// </summary>
-   class AutomateWPR
+namespace TestingPower
+{
+    /// <summary>
+    /// Provides Windows tracing controls using Windows Performance Recorder (WPR).
+    /// By default AutomateWPR assumes WPR has been installed on the test machine as part of the Windows Performance Toolkit.
+    /// Other WPR.exe can optionally be specified by passing the path to the WPR.exe location during instantiation.
+    ///
+    /// NOTE: TestingPower.exe must be run elevated in order to allow control of WPR.exe.
+    /// 
+    /// </summary>
+    internal class AutomateWPR
     {
-        private string wprExePath;
-        private string wprpFile;
+        private string _wprExePath;
+        private string _wprpFile;
 
         public string WprRecordingProfile
         {
             get
             {
-                return wprpFile;
+                return _wprpFile;
             }
             set
             {
-                this.wprpFile = value;
+                _wprpFile = value;
             }
         }
 
@@ -59,8 +60,8 @@ namespace TestingPower {
         /// </summary>
         public AutomateWPR()
         {
-            this.wprExePath = @"C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\wpr.exe";            
-            this.wprpFile = ""; // need a default wprp file
+            _wprExePath = @"C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\wpr.exe";
+            _wprpFile = ""; // need a default wprp file
         }
 
         /// <summary>
@@ -70,8 +71,8 @@ namespace TestingPower {
         /// <param name="wprPath">The WPR exe path and file name to use for controlling the WPR tracing.</param>
         public AutomateWPR(string wprpFile, string wprPath = @"C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\wpr.exe")
         {
-            this.wprExePath = wprPath;
-            this.wprpFile = wprpFile;
+            _wprExePath = wprPath;
+            _wprpFile = wprpFile;
         }
 
         /// <summary>
@@ -80,12 +81,12 @@ namespace TestingPower {
         /// <returns>0 if the trace session was started successfully.</returns>
         public int StartWPR()
         {
-            int _retVal = -1;
-            
-            string _commandLine = "-start " + this.wprpFile;
+            int retVal = -1;
 
-            _retVal = this.RunWpr(_commandLine);
-            return _retVal;
+            string _commandLine = "-start " + _wprpFile;
+
+            retVal = this.RunWpr(_commandLine);
+            return retVal;
         }
 
         /// <summary>
@@ -95,58 +96,58 @@ namespace TestingPower {
         /// <returns></returns>
         public int StopWPR(string etlFileName = "BrowserPower.etl")
         {
-            int _retVal = -1;
-            
-            string _commandLine = "-stop " + etlFileName;
+            int retVal = -1;
 
-            _retVal = this.RunWpr(_commandLine);
+            string commandLine = "-stop " + etlFileName;
 
-            return _retVal;
+            retVal = this.RunWpr(commandLine);
+
+            return retVal;
         }
 
         // executes the wpr.exe commandline with the passed in command line parameters
         private int RunWpr(string cmdLine)
         {
-            int _retVal = 1;
-            string errorOutput = "";            
+            int retVal = 1;
+            string errorOutput = "";
 
-            string _wprExe = System.IO.Path.Combine(this.wprExePath, "wpr.exe");
-            
+            string wprExe = System.IO.Path.Combine(_wprExePath, "wpr.exe");
+
             try
             {
-                ProcessStartInfo processInfo = new ProcessStartInfo(_wprExe);
-                processInfo.Arguments = cmdLine;                                
+                ProcessStartInfo processInfo = new ProcessStartInfo(wprExe);
+                processInfo.Arguments = cmdLine;
                 processInfo.UseShellExecute = false;
-                processInfo.RedirectStandardError = true;                
+                processInfo.RedirectStandardError = true;
 
                 Process commandProcess = new Process();
                 commandProcess.StartInfo = processInfo;
                 commandProcess.Start();
-                
+
                 // capture any error output. We'll use this to throw an exception.
                 errorOutput = commandProcess.StandardError.ReadToEnd();
 
                 commandProcess.WaitForExit();
-                
+
                 // output the standard error to the console window. The standard output is routed to the console window by default.
-                Console.WriteLine(errorOutput);                
-                                
-                if (!String.IsNullOrEmpty(errorOutput))
+                Console.WriteLine(errorOutput);
+
+                if (!string.IsNullOrEmpty(errorOutput))
                 {
                     throw new Exception(errorOutput.ToString());
                 }
 
-                _retVal = 0;
+                retVal = 0;
             }
             catch (Exception e)
             {
                 Console.WriteLine("Exception trying to run wpr.exe!");
                 Console.WriteLine(e.Message);
-                
-                _retVal = -1;
+
+                retVal = -1;
             }
 
-            return _retVal;
+            return retVal;
         }
     }
 }

--- a/TestingPower/AutomateWPR.cs
+++ b/TestingPower/AutomateWPR.cs
@@ -83,9 +83,9 @@ namespace TestingPower
         {
             int retVal = -1;
 
-            string _commandLine = "-start " + _wprpFile;
+            string commandLine = "-start " + _wprpFile;
 
-            retVal = this.RunWpr(_commandLine);
+            retVal = this.RunWpr(commandLine);
             return retVal;
         }
 

--- a/TestingPower/Program.cs
+++ b/TestingPower/Program.cs
@@ -25,7 +25,7 @@
 //
 //--------------------------------------------------------------
 
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
@@ -40,13 +40,13 @@ using System.Threading;
 
 namespace TestingPower
 {
-    class Program
+    internal class Program
     {
-        private static RemoteWebDriver driver;
-        private static string browser = string.Empty;
-        private static int loops = 1;
-        private static List<Scenario> scenarios = new List<Scenario>();
-        private static Dictionary<string, Scenario> possibleScenarios = new Dictionary<string, Scenario>();
+        private static RemoteWebDriver s_driver;
+        private static string s_browser = string.Empty;
+        private static int s_loops = 1;
+        private static List<Scenario> s_scenarios = new List<Scenario>();
+        private static Dictionary<string, Scenario> s_possibleScenarios = new Dictionary<string, Scenario>();
 
         private static void Main(string[] args)
         {
@@ -56,18 +56,18 @@ namespace TestingPower
             ProcessArgs(args);
 
             List<UserInfo> logins = GetLoginsFromFile();
-            
+
             // Core Execution Loop
-            using (var driver = CreateDriverAndMazimize(browser))
+            using (var driver = CreateDriverAndMazimize(s_browser))
             {
                 Stopwatch watch = Stopwatch.StartNew();
                 bool isFirstScenario = true;
 
                 // Allow multiple loops of all the scenarios if the user desires. Great for compounding small
                 // differences to make them easier to measure.
-                for (int loop = 0; loop < loops; loop++)
+                for (int loop = 0; loop < s_loops; loop++)
                 {
-                    foreach (var scenario in scenarios)
+                    foreach (var scenario in s_scenarios)
                     {
                         // We want every scenario to take the same amount of time total, even if there are changes in
                         // how long pages take to load. The biggest reason for this is so that you can measure energy
@@ -87,7 +87,7 @@ namespace TestingPower
                         }
 
                         // Here, control is handed to the scenario to navigate, and do whatever it wants
-                        scenario.Run(driver, browser, logins);
+                        scenario.Run(driver, s_browser, logins);
 
                         // When we get control back, we sleep for the remaining time for the scenario. This ensures
                         // the total time for a scenario is always the same
@@ -128,7 +128,7 @@ namespace TestingPower
 
         private static void AddScenario(Scenario scenario)
         {
-            possibleScenarios.Add(scenario.Name, scenario);
+            s_possibleScenarios.Add(scenario.Name, scenario);
         }
 
         /// <summary>
@@ -143,15 +143,15 @@ namespace TestingPower
             // Processes the arguments. Here we'll decide which browser, scenarios, and number of loops to run
 
             Console.WriteLine("Usage: TestingPower.exe -browser [chrome|edge|firefox|opera|operabeta] -scenario all|<scenario1> <scenario2> [-loops <loopcount>]");
-            for (int argNum = 0; argNum < args.Length;  argNum++)
+            for (int argNum = 0; argNum < args.Length; argNum++)
             {
                 var arg = args[argNum].ToLowerInvariant();
                 switch (arg)
                 {
                     case "-browser":
                         argNum++;
-                        browser = args[argNum].ToLowerInvariant();
-                        switch (browser)
+                        s_browser = args[argNum].ToLowerInvariant();
+                        switch (s_browser)
                         {
                             case "operabeta":
                             case "opera":
@@ -160,7 +160,7 @@ namespace TestingPower
                             case "edge":
                                 break;
                             default:
-                                throw new Exception($"Unexpected browser '{browser}'");
+                                throw new Exception($"Unexpected browser '{s_browser}'");
                         }
 
                         break;
@@ -170,14 +170,14 @@ namespace TestingPower
                         if (args[argNum] == "all")
                         {
                             // Specify the "official" runs, including order
-                            scenarios.Add(possibleScenarios["youtube"]);
-                            scenarios.Add(possibleScenarios["cnn"]);
-                            scenarios.Add(possibleScenarios["techRadar"]);
-                            scenarios.Add(possibleScenarios["amazon"]);
-                            scenarios.Add(possibleScenarios["facebook"]);
-                            scenarios.Add(possibleScenarios["google"]);
-                            scenarios.Add(possibleScenarios["gmail"]);
-                            scenarios.Add(possibleScenarios["wikipedia"]);
+                            s_scenarios.Add(s_possibleScenarios["youtube"]);
+                            s_scenarios.Add(s_possibleScenarios["cnn"]);
+                            s_scenarios.Add(s_possibleScenarios["techRadar"]);
+                            s_scenarios.Add(s_possibleScenarios["amazon"]);
+                            s_scenarios.Add(s_possibleScenarios["facebook"]);
+                            s_scenarios.Add(s_possibleScenarios["google"]);
+                            s_scenarios.Add(s_possibleScenarios["gmail"]);
+                            s_scenarios.Add(s_possibleScenarios["wikipedia"]);
 
                             break;
                         }
@@ -185,14 +185,14 @@ namespace TestingPower
                         while (argNum < args.Length)
                         {
                             var scenario = args[argNum];
-                            if (!possibleScenarios.ContainsKey(scenario))
+                            if (!s_possibleScenarios.ContainsKey(scenario))
                             {
                                 throw new Exception($"Unexpected scenario '{scenario}'");
                             }
 
-                            scenarios.Add(possibleScenarios[scenario]);
+                            s_scenarios.Add(s_possibleScenarios[scenario]);
                             int nextArgNum = argNum + 1;
-                            if (nextArgNum < args.Length && args[argNum+1].StartsWith("-"))
+                            if (nextArgNum < args.Length && args[argNum + 1].StartsWith("-"))
                             {
                                 break;
                             }
@@ -203,7 +203,7 @@ namespace TestingPower
                         break;
                     case "-loops":
                         argNum++;
-                        loops = int.Parse(args[argNum]);
+                        s_loops = int.Parse(args[argNum]);
                         break;
                     default:
                         throw new Exception($"Unexpected argument encountered '{args[argNum]}'");
@@ -214,10 +214,9 @@ namespace TestingPower
         private static void CloseTabs()
         {
             // Simply go through and close every tab one by one.
-            foreach (var window in driver.WindowHandles)
+            foreach (var window in s_driver.WindowHandles)
             {
-                driver.SwitchTo().Window(window).Close();
-
+                s_driver.SwitchTo().Window(window).Close();
             }
         }
 
@@ -242,7 +241,7 @@ namespace TestingPower
             // Use the page down key.
             for (int i = 0; i < timesToScroll; i++)
             {
-                driver.Keyboard.SendKeys(Keys.PageDown);
+                s_driver.Keyboard.SendKeys(Keys.PageDown);
                 Thread.Sleep(1000);
             }
         }
@@ -253,26 +252,26 @@ namespace TestingPower
         private static void CreateNewTab()
         {
             // Sadly, we had to special case this a bit by browser because no mechanism behaved correctly for everyone
-            if (browser == "firefox")
+            if (s_browser == "firefox")
             {
                 // Use ctrl+t for Firefox. Send them to the body or else there can be focus problems.
-                IWebElement body = driver.FindElementByTagName("body");
-                body.SendKeys(Keys.Control + 't');                
+                IWebElement body = s_driver.FindElementByTagName("body");
+                body.SendKeys(Keys.Control + 't');
             }
             else
             {
                 // For other browsers, use some JS. Note that this means you have to disable popup blocking in Edge
                 // You actually have to in Opera too, but that's provided in a flag below
-                driver.ExecuteScript("window.open();");
+                s_driver.ExecuteScript("window.open();");
                 // Go to that tab
-                driver.SwitchTo().Window(driver.WindowHandles[driver.WindowHandles.Count-1]);
+                s_driver.SwitchTo().Window(s_driver.WindowHandles[s_driver.WindowHandles.Count - 1]);
             }
 
             // Give the browser more than enough time to open the tab and get to it so the next commands from the
             // scenario don't get lost
             Thread.Sleep(2000);
         }
-        
+
         private static RemoteWebDriver CreateDriverAndMazimize(string browser)
         {
             // Create a webdriver for the respective browser, depending on what we're testing.
@@ -289,28 +288,28 @@ namespace TestingPower
                         // rather than depending on flaky hard-coded version in directory
                         oOption.BinaryLocation = @"C:\Program Files (x86)\Opera beta\38.0.2220.25\opera.exe";
                     }
-                    driver = new OperaDriver(oOption);
+                    s_driver = new OperaDriver(oOption);
                     break;
                 case "firefox":
-                    driver = new FirefoxDriver();
+                    s_driver = new FirefoxDriver();
                     break;
                 case "chrome":
                     ChromeOptions option = new ChromeOptions();
                     option.AddUserProfilePreference("profile.default_content_setting_values.notifications", 1);
-                    driver = new ChromeDriver(option);
+                    s_driver = new ChromeDriver(option);
                     break;
                 default:
                     EdgeOptions options = new EdgeOptions();
-                    options.PageLoadStrategy = EdgePageLoadStrategy.Normal;                    
-                    driver = new EdgeDriver(options);
+                    options.PageLoadStrategy = EdgePageLoadStrategy.Normal;
+                    s_driver = new EdgeDriver(options);
                     break;
             }
 
-            driver.Manage().Window.Maximize();
+            s_driver.Manage().Window.Maximize();
 
             Thread.Sleep(1000);
 
-            return driver;
+            return s_driver;
         }
         /// <summary>
         /// Here we do the work to finish the test, like quitting the driver.
@@ -320,7 +319,7 @@ namespace TestingPower
             // TODO: Capture power usage / results automatically
             try
             {
-                driver.Quit();
+                s_driver.Quit();
             }
             catch (Exception)
             {
@@ -332,7 +331,7 @@ namespace TestingPower
         {
             try
             {
-                driver.SwitchTo().Alert();
+                s_driver.SwitchTo().Alert();
                 return true;
             }
             catch (NoAlertPresentException)

--- a/TestingPower/Properties/AssemblyInfo.cs
+++ b/TestingPower/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TestingPower")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright \u00A9 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TestingPower/Scenario.cs
+++ b/TestingPower/Scenario.cs
@@ -25,13 +25,12 @@
 //
 //--------------------------------------------------------------
 
-﻿using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
 
 namespace TestingPower
 {
-
-     // All scenarios will inherit from this class
+    // All scenarios will inherit from this class
     internal abstract class Scenario
     {
         public string Name { get; set; }

--- a/TestingPower/Scenarios/AmazonSearch.cs
+++ b/TestingPower/Scenarios/AmazonSearch.cs
@@ -25,7 +25,7 @@
 //
 //--------------------------------------------------------------
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using OpenQA.Selenium.Remote;
@@ -33,7 +33,7 @@ using OpenQA.Selenium;
 
 namespace TestingPower
 {
-    class AmazonSearch : Scenario
+    internal class AmazonSearch : Scenario
     {
         public AmazonSearch()
         {
@@ -61,7 +61,7 @@ namespace TestingPower
 
             // Click into "Game of Thrones Season 1"
             var bookLink = driver.FindElementByXPath("//*[@title='Game of Thrones Season 1']");
-            bookLink.SendKeys(String.Empty);
+            bookLink.SendKeys(string.Empty);
             driver.Keyboard.SendKeys(Keys.Enter);
 
             // And let that load

--- a/TestingPower/Scenarios/CnnTopStory.cs
+++ b/TestingPower/Scenarios/CnnTopStory.cs
@@ -25,7 +25,7 @@
 //
 //--------------------------------------------------------------
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium;
@@ -33,7 +33,7 @@ using System.Threading;
 
 namespace TestingPower
 {
-    class CnnTopStory : Scenario
+    internal class CnnTopStory : Scenario
     {
         public CnnTopStory()
         {
@@ -48,13 +48,13 @@ namespace TestingPower
             driver.Navigate().GoToUrl("http://www.cnn.com");
 
             // Give it more than enough time to load
-            Thread.Sleep(5000); 
+            Thread.Sleep(5000);
 
             // Get the element that contains the headline story
             var headlineElement = driver.FindElementByClassName("js-screaming-banner");
 
             // Get focus on the headline story link
-            headlineElement.SendKeys(String.Empty);
+            headlineElement.SendKeys(string.Empty);
 
             // Open the link to the headline story
             headlineElement.SendKeys(Keys.Enter);

--- a/TestingPower/Scenarios/FacebookNewsfeedScroll.cs
+++ b/TestingPower/Scenarios/FacebookNewsfeedScroll.cs
@@ -25,14 +25,14 @@
 //
 //--------------------------------------------------------------
 
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium;
 using System.Threading;
 
 namespace TestingPower
 {
-    class FacebookNewsfeedScroll : Scenario
+    internal class FacebookNewsfeedScroll : Scenario
     {
         public FacebookNewsfeedScroll()
         {

--- a/TestingPower/Scenarios/GmailGoThroughEmails.cs
+++ b/TestingPower/Scenarios/GmailGoThroughEmails.cs
@@ -31,10 +31,10 @@ using System.Threading;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium;
 
-namespace TestingPower {
-   class GmailGoThroughEmails : Scenario
+namespace TestingPower
+{
+    internal class GmailGoThroughEmails : Scenario
     {
-
         public GmailGoThroughEmails()
         {
             Name = "gmail";
@@ -58,8 +58,8 @@ namespace TestingPower {
         private void LogIn(RemoteWebDriver driver, List<UserInfo> logins)
         {
             // Get the relevant username and password
-            String username = "";
-            String password = "";
+            string username = "";
+            string password = "";
             foreach (UserInfo item in logins)
             {
                 if (item.Domain == "gmail.com")
@@ -84,7 +84,7 @@ namespace TestingPower {
                 // ...but if we couldn't find it, we apparently got sereved this other log in page.
                 // So catch the exception and get to the login page we're looking for
                 var signInButton = driver.FindElementByXPath("//*[@data-g-label='Sign in']");
-                signInButton.SendKeys(String.Empty);
+                signInButton.SendKeys(string.Empty);
                 driver.Keyboard.SendKeys(Keys.Enter);
                 Thread.Sleep(2 * 1000);
                 userElement = driver.FindElementById("Email");

--- a/TestingPower/Scenarios/GoogleSearch.cs
+++ b/TestingPower/Scenarios/GoogleSearch.cs
@@ -30,8 +30,9 @@ using System.Threading;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium;
 
-namespace TestingPower {
-   class GoogleSearch : Scenario
+namespace TestingPower
+{
+    internal class GoogleSearch : Scenario
     {
         public GoogleSearch()
         {

--- a/TestingPower/Scenarios/Msn.cs
+++ b/TestingPower/Scenarios/Msn.cs
@@ -25,13 +25,13 @@
 //
 //--------------------------------------------------------------
 
-﻿using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace TestingPower
 {
-    class Msn : Scenario
+    internal class Msn : Scenario
     {
         public Msn()
         {

--- a/TestingPower/Scenarios/Msnbc.cs
+++ b/TestingPower/Scenarios/Msnbc.cs
@@ -25,16 +25,16 @@
 //
 //--------------------------------------------------------------
 
-﻿using OpenQA.Selenium;
+using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace TestingPower
 {
-    class Msnbc : Scenario
+    internal class Msnbc : Scenario
     {
-        public Msnbc ()
+        public Msnbc()
         {
             Name = "msnbc";
             Duration = 50;
@@ -50,7 +50,6 @@ namespace TestingPower
             // first get back to the top
             driver.ExecuteScript("return window.scrollTo(0,0);");
             Thread.Sleep(2000);
-
         }
 
         private static void ClickMsnbcLink(RemoteWebDriver driver)

--- a/TestingPower/Scenarios/OutlookViewEmails.cs
+++ b/TestingPower/Scenarios/OutlookViewEmails.cs
@@ -31,8 +31,9 @@ using OpenQA.Selenium.Remote;
 using System.Threading;
 using OpenQA.Selenium;
 
-namespace TestingPower {
-   class OutlookViewEmails : Scenario
+namespace TestingPower
+{
+    internal class OutlookViewEmails : Scenario
     {
         public OutlookViewEmails()
         {

--- a/TestingPower/Scenarios/RedditSearchSubreddit.cs
+++ b/TestingPower/Scenarios/RedditSearchSubreddit.cs
@@ -30,8 +30,9 @@ using OpenQA.Selenium.Remote;
 using System.Threading;
 using OpenQA.Selenium;
 
-namespace TestingPower {
-   class RedditSearchSubreddit : Scenario
+namespace TestingPower
+{
+    internal class RedditSearchSubreddit : Scenario
     {
         public RedditSearchSubreddit()
         {

--- a/TestingPower/Scenarios/TechRadarSurfacePro4Review.cs
+++ b/TestingPower/Scenarios/TechRadarSurfacePro4Review.cs
@@ -29,8 +29,9 @@ using System.Collections.Generic;
 using OpenQA.Selenium.Remote;
 using System.Threading;
 
-namespace TestingPower {
-   class TechRadarSurfacePro4Review : Scenario
+namespace TestingPower
+{
+    internal class TechRadarSurfacePro4Review : Scenario
     {
         public TechRadarSurfacePro4Review()
         {

--- a/TestingPower/Scenarios/WikipediaUnitedStates.cs
+++ b/TestingPower/Scenarios/WikipediaUnitedStates.cs
@@ -30,8 +30,9 @@ using System.Collections.Generic;
 using OpenQA.Selenium.Remote;
 using System.Threading;
 
-namespace TestingPower {
-   class WikipediaUnitedStates : Scenario
+namespace TestingPower
+{
+    internal class WikipediaUnitedStates : Scenario
     {
         public WikipediaUnitedStates()
         {
@@ -48,7 +49,7 @@ namespace TestingPower {
             if (browser == "firefox")
             {
                 // With Firefox, we had to get focus onto the page, or else PgDn scrolled through the address bar
-                driver.FindElementById("firstHeading").SendKeys(String.Empty);
+                driver.FindElementById("firstHeading").SendKeys(string.Empty);
             }
 
             // Scroll a bit

--- a/TestingPower/Scenarios/YoutubeWatchVideo.cs
+++ b/TestingPower/Scenarios/YoutubeWatchVideo.cs
@@ -25,13 +25,13 @@
 //
 //--------------------------------------------------------------
 
-﻿using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace TestingPower
 {
-    class YoutubeWatchVideo : Scenario
+    internal class YoutubeWatchVideo : Scenario
     {
         public YoutubeWatchVideo()
         {

--- a/TestingPower/UserInfo.cs
+++ b/TestingPower/UserInfo.cs
@@ -25,11 +25,11 @@
 //
 //--------------------------------------------------------------
 
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace TestingPower
 {
-    class UserInfo
+    internal class UserInfo
     {
         [JsonProperty("Domain")]
         public string Domain { get; set; }


### PR DESCRIPTION
… keep the current MIT copyright headers.

Changed BCL 'String' references to 'string' references per dotnet corefx coding style.

Removed underscores from method variables.
