### PR TITLE
Added ability to override timeout

### DIFF
--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -53,6 +53,7 @@ namespace BrowserEfficiencyTest
         public bool UsingTraceController { get; private set; }
         public string EtlPath { get; private set; }
         public int MaxAttempts { get; private set; }
+        public bool OverrideTimeout { get; private set;  }
 
         /// <summary>
         /// List of all scenarios to be run.
@@ -100,6 +101,7 @@ namespace BrowserEfficiencyTest
             UsingTraceController = false;
             EtlPath = "";
             MaxAttempts = 3;
+            OverrideTimeout = false;
 
             CreatePossibleScenarios();
             ProcessArgs(args);
@@ -259,6 +261,10 @@ namespace BrowserEfficiencyTest
                         {
                             throw new DirectoryNotFoundException("The profile path does not exist!");
                         }
+                        break;
+                    case "-notimeout":
+                        argNum++;
+                        OverrideTimeout = true;
                         break;
                     default:
                         throw new Exception($"Unexpected argument encountered '{args[argNum]}'");

--- a/BrowserEfficiencyTest/ScenarioRunner.cs
+++ b/BrowserEfficiencyTest/ScenarioRunner.cs
@@ -235,10 +235,12 @@ namespace BrowserEfficiencyTest
                                                 // continue to the next scenario. In that case, invalidate the run by throwing.
                                                 throw new Exception(string.Format("Scenario ran longer than expected! The browser ran for {0}s. The timeout for this scenario is {1}s.", runTime.TotalSeconds, scenario.Duration));
                                             }
+                                            else if (!_overrideTimeout)
+                                            {
+                                                Thread.Sleep(timeLeft);
+                                            }
 
-                                            Console.WriteLine("[{0}] - Completed - Iteration: {1}  Browser: {2}  Scenario: {3}  MeasureSet: {4}. Scenario ran for {5} seconds.", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), iteration, browser, scenario.Name, currentMeasureSet.Key, runTime.TotalSeconds);
-
-                                            Thread.Sleep(timeLeft);
+                                            Console.WriteLine("[{0}] - Completed - Iteration: {1}  Browser: {2}  Scenario: {3}  MeasureSet: {4}. Scenario ran for {5} seconds.", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), iteration, browser, scenario.Name, currentMeasureSet.Key, runTime.TotalSeconds); 
                                         }
 
                                         Console.WriteLine("[{0}] - Completed Browser: {1}  Iteration: {2}  MeasureSet: {3}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), browser, iteration, currentMeasureSet.Key);

--- a/BrowserEfficiencyTest/ScenarioRunner.cs
+++ b/BrowserEfficiencyTest/ScenarioRunner.cs
@@ -47,6 +47,7 @@ namespace BrowserEfficiencyTest
         private string _browserProfilePath;
         private bool _usingTraceController;
         private string _etlPath;
+        private bool _overrideTimeout;
 
         private List<Scenario> _scenarios = new List<Scenario>();
         private List<string> _browsers = new List<string>();
@@ -72,6 +73,7 @@ namespace BrowserEfficiencyTest
             _usingTraceController = args.UsingTraceController;
             _etlPath = args.EtlPath;
             _maxAttempts = args.MaxAttempts;
+            _overrideTimeout = args.OverrideTimeout;
 
             _scenarios = args.Scenarios.ToList();
             _browsers = args.Browsers.ToList();
@@ -227,7 +229,7 @@ namespace BrowserEfficiencyTest
                                             // the total time for a scenario is always the same
                                             var runTime = watch.Elapsed.Subtract(startTime);
                                             var timeLeft = TimeSpan.FromSeconds(scenario.Duration).Subtract(runTime);
-                                            if (timeLeft < TimeSpan.FromSeconds(0))
+                                            if (timeLeft < TimeSpan.FromSeconds(0) && !_overrideTimeout)
                                             {
                                                 // Of course it's possible we don't get control back until after we were supposed to
                                                 // continue to the next scenario. In that case, invalidate the run by throwing.

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -59,6 +59,8 @@ BrowserEfficiencyTest.exe -browser|-b [chrome|edge|firefox|opera|operabeta] -sce
 
 *   **-attempts|-a** Defines the number of attempts to make per iteration. If an exception is caught, the trace is discarded and a new attempt is made. This paramater allows you to override the default number of attempts before giving up on the iteration, which is 3.
 
+*   **-notimeout** Allows the test run to continue even if the scenario took longer than expected to complete. Without this flag, the test harness will throw out the run and attempt again if any scenario takes longer to complete than its specified duration.
+
 ## Examples
 
 ### Simple one tab, one browser, no measures


### PR DESCRIPTION
When `-notimeout` is provided, the test run will continue even if a scenario runs longer than its expected duration