### PR TITLE
Removed Pinterest from workloads

### DIFF
--- a/BrowserEfficiencyTest/workloads.json
+++ b/BrowserEfficiencyTest/workloads.json
@@ -51,11 +51,6 @@
         "Duration": 180
       },
       {
-        "ScenarioName": "pinterest",
-        "Tab": "same",
-        "Duration": 180
-      },
-      {
         "ScenarioName": "twitter",
         "Tab": "same",
         "Duration": 180
@@ -123,11 +118,6 @@
         "ScenarioName": "espn",
         "Tab": "same",
         "Duration": 45
-      },
-      {
-        "ScenarioName": "pinterest",
-        "Tab": "same",
-        "Duration": 60
       },
       {
         "ScenarioName": "twitter",


### PR DESCRIPTION
Was inconsistent and causing test failures in my tests. Removing from official workloads, at least temporarily