### PR TITLE
Brheenan update workloads

### DIFF
--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0")]
+[assembly: AssemblyVersion("3.0")]

--- a/BrowserEfficiencyTest/Scenarios/BbcNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/BbcNews.cs
@@ -43,7 +43,7 @@ namespace BrowserEfficiencyTest
         public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
         {
             // Navigate
-            driver.Navigate().GoToUrl("http://www.bbc.co.uk");
+            driver.Navigate().GoToUrl("http://www.bbc.com");
             driver.Wait(10);
 
             // Navigate to the hero headline

--- a/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
+++ b/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
@@ -74,7 +74,7 @@ namespace BrowserEfficiencyTest
 
             // Once we're logged in, all we're going to do is scroll through the page
             // We're simply measuring a user looking through their news feed for a minute
-
+            driver.Wait(5);
             driver.ScrollPage(20);
         }
     }

--- a/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
+++ b/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
@@ -54,7 +54,7 @@ namespace BrowserEfficiencyTest
             driver.Wait(3);
 
             // Then scroll through it
-            driver.ScrollPage(5);
+            driver.ScrollPage(8);
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -45,7 +45,8 @@ namespace BrowserEfficiencyTest
             // Nagivate to wikipedia
             driver.Navigate().GoToUrl("https://en.wikipedia.org/wiki/United_States");
 
-            Thread.Sleep(2 * 1000);
+            driver.Wait(5);
+
             if (browser == "firefox")
             {
                 // With Firefox, we had to get focus onto the page, or else PgDn scrolled through the address bar

--- a/BrowserEfficiencyTest/Scenarios/YahooNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/YahooNews.cs
@@ -44,20 +44,28 @@ namespace BrowserEfficiencyTest
         public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
         {
             driver.Navigate().GoToUrl("http://www.yahoo.com");
-            driver.Wait(10);
+            driver.Wait(5);
 
             // No reliable class or id for the news link, so get the news icon, then find its parent
             IWebElement newsLink = driver.FindElementByClassName("IconNews").FindElement(By.XPath(".."));
-            newsLink.SendKeys(String.Empty);
-            newsLink.SendKeys(Keys.Enter);
+            driver.ClickElement(newsLink);
 
-            Thread.Sleep(10000);
+            driver.Wait(5);
 
             // Get the "mega" story and navigate to it
             // We appear to be taking advantage of a test hook in the page for their own tests
             IWebElement mega = driver.FindElement(By.XPath("//*[@data-test-locator='mega']"));
             IWebElement articleLink = mega.FindElement(By.TagName("h3")).FindElement(By.TagName("a"));
             driver.ClickElement(articleLink);
+
+            driver.Wait(10);
+            driver.ScrollPage(2);
+            driver.Wait(10);
+            driver.ScrollPage(2);
+            driver.Wait(10);
+
+            // Then go back to the news homepage
+            driver.Navigate().Back();
         }
     }
 }

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -21,8 +21,7 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -sc
 
 *   **-workload|-w** Selects the workload to run. This option must be provided unless a scenario is provided instead. The possible options are provided here, but they can be easily modified in `workloads.json`:
 
-    *   `representativelong` This workload runs through 13 common sites across 4 tabs, spending a few minutes on each one with some meaningful interaction with each of them. This workload takes 40 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook, Gmail, and Pinterest.
-    *   `representativeshort` This workload runs through 13 common sites across 4 tabs, spending between 45s and 90s on each one with some meaningful interaction with each of them. It is very similar to the above workload, but takes less time to execute. This workload takes 15 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook, Gmail, and Pinterest.
+    *   `representative` This workload runs through 12 common sites across 4 tabs, spending a minute and a half on each one, with some meaningful interaction with each of them. This workload takes 18 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook and Gmail.
     *   `heavymultitab` This workload runs through 8 sites all in different tabs, with interaction on each of them. It represents heavy usage of the browser especially across many tabs. It takes about 8 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook and Gmail.
 
 *   **-scenario|-s** Selects the scenario or scenarios to run. This option must be provided unless a workload is provided instead. Multiple scenarios can be selected by separating each scenario with a space. E.g. `-s wikipedia gmail facebook`. When multiple scenarios are selected, they will all be run on every browser, in the order they were provided, all in different tabs. When a scenario completes and there's additional scenarios after it, it will be left running in a background tab. The possible options are:
@@ -52,7 +51,7 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -sc
     *   `tumblr` will navigate to tumblr.com, click on "staff picks", then click on "trending", before scrolling through the trending posts
     *   `twitter` will navigate to twitter and scroll through the featured posts on the homepage
     *   `wikipedia` will navigate to the Wikipedia article on the United States and scroll
-    *   `yahooNews` will navigate to Yahoo.com, go to news, and navigate to the top story. It will then scroll through it
+    *   `yahooNews` will navigate to Yahoo.com, go to news, and navigate to the top story. It will then scroll through it before going back to the listing of all news.
     *   `yelp` will navigate to Yelp, search for a restaurant, and click into it
     *   `youtube` will play the video "Microsoft Design: Connecting Makers" on Youtube
     *   `zillow` will load a map of places for sale, expand the map view, then load the top listing

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0")]
+[assembly: AssemblyVersion("3.0")]


### PR DESCRIPTION
* BBC news goes to bbc.com instead of bbc.co.uk. It was being redirected anyways and introducing more variability than value
* Pause in Facebook before scrolling to allow more loading
* More scrolling in Instagram
* Extra pause in Wikipedia before scrolling
* Yahoo news scrolls and navigates back to the news stories listing before ending to reduce variability when left in the background, as it is on the representative workload
* Docs updated
* Version -> 3.0