### PR TITLE
Added responsiveness measures

### DIFF
--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -122,7 +122,7 @@ namespace BrowserEfficiencyTest
         private void ProcessArgs(string[] args)
         {
             // Processes the arguments. Here we'll decide which browser, scenarios, and number of loops to run
-            Console.WriteLine("Usage: BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -scenario|-s <scenario1> <scenario2>] [-iterations|-i <iterationcount>] [-resultspath|-rp <etlpath>] [-measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np][-workload|-w <workload name>] [-credentialpath|-cp <path to credentials json file>]");
+            Console.WriteLine("Usage: BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -scenario|-s <scenario1> <scenario2>] [-iterations|-i <iterationcount>] [-resultspath|-rp <etlpath>] [-measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np][-workload|-w <workload name>] [-credentialpath|-cp <path to credentials json file>] [-responsiveness|-r]");
             for (int argNum = 0; argNum < args.Length; argNum++)
             {
                 var arg = args[argNum].ToLowerInvariant();

--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -104,7 +104,7 @@ namespace BrowserEfficiencyTest
             DoWarmup = false;
             Iterations = 1;
             UsingTraceController = false;
-            EtlPath = ".";
+            EtlPath = Directory.GetCurrentDirectory();
             MaxAttempts = 3;
             OverrideTimeout = false;
             DoPostProcessing = true;
@@ -122,7 +122,7 @@ namespace BrowserEfficiencyTest
         private void ProcessArgs(string[] args)
         {
             // Processes the arguments. Here we'll decide which browser, scenarios, and number of loops to run
-            Console.WriteLine("Usage: BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -scenario|-s <scenario1> <scenario2>] [-iterations|-i <iterationcount>] [-tracecontrolled|-tc <etlpath> -measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np][-workload|-w <workload name>] [-credentialpath|-cp <path to credentials json file>]");
+            Console.WriteLine("Usage: BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] -scenario|-s <scenario1> <scenario2>] [-iterations|-i <iterationcount>] [-resultspath|-rp <etlpath>] [-measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np][-workload|-w <workload name>] [-credentialpath|-cp <path to credentials json file>]");
             for (int argNum = 0; argNum < args.Length; argNum++)
             {
                 var arg = args[argNum].ToLowerInvariant();
@@ -209,9 +209,8 @@ namespace BrowserEfficiencyTest
                         }
 
                         break;
-                    case "-tracecontrolled":
-                    case "-tc":
-                        UsingTraceController = true;
+                    case "-resultspath":
+                    case "-rp":
                         argNum++;
                         string etlPath = args[argNum];
 
@@ -234,6 +233,8 @@ namespace BrowserEfficiencyTest
                             {
                                 throw new Exception($"Unexpected measure set '{measureSet}'");
                             }
+
+                            UsingTraceController = true;
 
                             _selectedMeasureSets.Add(_availableMeasureSets[measureSet]);
 
@@ -288,16 +289,6 @@ namespace BrowserEfficiencyTest
                     default:
                         throw new Exception($"Unexpected argument encountered '{args[argNum]}'");
                 }
-            }
-
-            // For perf processing, ensure that both the tracing controller option and measuresets have been selected
-            if (UsingTraceController && _selectedMeasureSets.Count == 0)
-            {
-                throw new Exception("A measure set must be specified when using a trace controller.");
-            }
-            else if (!UsingTraceController && _selectedMeasureSets.Count > 0)
-            {
-                throw new Exception("The tracing controller option must be specified when using measure sets.");
             }
         }
 

--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -104,7 +104,7 @@ namespace BrowserEfficiencyTest
             DoWarmup = false;
             Iterations = 1;
             UsingTraceController = false;
-            EtlPath = "";
+            EtlPath = ".";
             MaxAttempts = 3;
             OverrideTimeout = false;
             DoPostProcessing = true;

--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -57,6 +57,7 @@ namespace BrowserEfficiencyTest
         public bool OverrideTimeout { get; private set;  }
         public bool DoPostProcessing { get; private set; }
         public string CredentialPath { get; private set; }
+        public bool MeasureResponsiveness { get; private set; }
 
         /// <summary>
         /// List of all scenarios to be run.
@@ -108,6 +109,7 @@ namespace BrowserEfficiencyTest
             OverrideTimeout = false;
             DoPostProcessing = true;
             CredentialPath = "credentials.json";
+            MeasureResponsiveness = false;
 
             CreatePossibleScenarios();
             ProcessWorkloads();
@@ -278,6 +280,10 @@ namespace BrowserEfficiencyTest
                     case "-cp":
                         argNum++;
                         CredentialPath = args[argNum];
+                        break;
+                    case "-responsiveness":
+                    case "-r":
+                        MeasureResponsiveness = true;
                         break;
                     default:
                         throw new Exception($"Unexpected argument encountered '{args[argNum]}'");

--- a/BrowserEfficiencyTest/BrowserEfficiencyTest.csproj
+++ b/BrowserEfficiencyTest/BrowserEfficiencyTest.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="Arguments.cs" />
     <Compile Include="CredentialManager.cs" />
+    <Compile Include="ResponsivenessTimer.cs" />
     <Compile Include="Scenarios\AboutBlank.cs" />
     <Compile Include="Scenarios\AzureDashboard.cs" />
     <Compile Include="Scenarios\EspnHomepage.cs" />

--- a/BrowserEfficiencyTest/Program.cs
+++ b/BrowserEfficiencyTest/Program.cs
@@ -34,19 +34,25 @@ namespace BrowserEfficiencyTest
         private static void Main(string[] args)
         {
             Arguments arguments = new Arguments(args);
+            ScenarioRunner scenarioRunner = new ScenarioRunner(arguments);
 
             if (arguments.Browsers.Count > 0 && arguments.Scenarios.Count > 0)
             {
-                ScenarioRunner scenarioRunner = new ScenarioRunner(arguments);
-
                 scenarioRunner.Run();
             }
 
-            if (arguments.UsingTraceController && arguments.DoPostProcessing)
+            if ((arguments.UsingTraceController && arguments.DoPostProcessing) || arguments.MeasureResponsiveness)
             {
                 PerfProcessor perfProcessor = new PerfProcessor((arguments.SelectedMeasureSets).ToList());
 
-                perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath);
+                if (!arguments.MeasureResponsiveness)
+                {
+                    perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath);
+                }
+                else
+                {
+                    perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.getResponsivnessResults());
+                }
             }
         }
     }

--- a/BrowserEfficiencyTest/Program.cs
+++ b/BrowserEfficiencyTest/Program.cs
@@ -47,16 +47,7 @@ namespace BrowserEfficiencyTest
             if ((arguments.UsingTraceController && arguments.DoPostProcessing) || arguments.MeasureResponsiveness)
             {
                 PerfProcessor perfProcessor = new PerfProcessor((arguments.SelectedMeasureSets).ToList());
-
-                if (!arguments.MeasureResponsiveness)
-                {
-                    perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath);
-                }
-                else
-                {
-                    // If we have responsiveness results, pass them to the perf processor to include in the output
-                    perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.getResponsivnessResults());
-                }
+                perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.getResponsivnessResults());
             }
         }
     }

--- a/BrowserEfficiencyTest/Program.cs
+++ b/BrowserEfficiencyTest/Program.cs
@@ -47,7 +47,7 @@ namespace BrowserEfficiencyTest
             if ((arguments.UsingTraceController && arguments.DoPostProcessing) || arguments.MeasureResponsiveness)
             {
                 PerfProcessor perfProcessor = new PerfProcessor((arguments.SelectedMeasureSets).ToList());
-                perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.getResponsivnessResults());
+                perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.GetResponsivenessResults());
             }
         }
     }

--- a/BrowserEfficiencyTest/Program.cs
+++ b/BrowserEfficiencyTest/Program.cs
@@ -36,11 +36,14 @@ namespace BrowserEfficiencyTest
             Arguments arguments = new Arguments(args);
             ScenarioRunner scenarioRunner = new ScenarioRunner(arguments);
 
+            // Run the automation. This will write traces to the current or provided directory if the user requested it
             if (arguments.Browsers.Count > 0 && arguments.Scenarios.Count > 0)
             {
                 scenarioRunner.Run();
             }
 
+            // If traces have been written, process them into a csv of results
+            // Only necessary if we're tracing and/or measuring responsiveness
             if ((arguments.UsingTraceController && arguments.DoPostProcessing) || arguments.MeasureResponsiveness)
             {
                 PerfProcessor perfProcessor = new PerfProcessor((arguments.SelectedMeasureSets).ToList());
@@ -51,6 +54,7 @@ namespace BrowserEfficiencyTest
                 }
                 else
                 {
+                    // If we have responsiveness results, pass them to the perf processor to include in the output
                     perfProcessor.Execute(arguments.EtlPath, arguments.EtlPath, scenarioRunner.getResponsivnessResults());
                 }
             }

--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0")]
+[assembly: AssemblyVersion("7.0")]

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -8,6 +8,10 @@ using System.Threading.Tasks;
 
 namespace BrowserEfficiencyTest
 {
+
+    /// <summary>
+    /// Handles the logic for measuring user-perceivable performance. This class makes it easy for scenarios to measure page load time etc
+    /// </summary>
     internal class ResponsivenessTimer
     {
         private List<List<String>> _results;
@@ -20,43 +24,72 @@ namespace BrowserEfficiencyTest
 
         // Functions for test harness:
 
+        /// <summary>
+        /// Creates a new ResponsivenessTimer. It will be disabled unless enabled later on. When disabled, all calls that create measures will be no-ops.
+        /// </summary>
         public ResponsivenessTimer()
         {
             _results = new List<List<String>>();
             _enabled = false;
         }
 
+        /// <summary>
+        /// Sets the iteration, which will be included when a measurement is recorded later.
+        /// </summary>
+        /// <param name="iteration">The current iteration</param>
         public void setIteration(int iteration)
         {
             _iteration = iteration;
         }
 
+        /// <summary>
+        /// Sets the browser, which will be included when a measurement is recorded later.
+        /// </summary>
+        /// <param name="browser">The current browser</param>
         public void setBrowser(string browser)
         {
             _browser = browser;
         }
 
+        /// <summary>
+        /// Sets the measureSet, which will be included when a measurement is recorded later.
+        /// </summary>
+        /// <param name="measureSet"></param>
         public void setMeasureSet(string measureSet)
         {
             _measureSet = measureSet;
         }
 
+        /// <summary>
+        /// Sets the sceanrio, which will be included when a measurement is recorded later.
+        /// </summary>
+        /// <param name="scenario">The current scenario</param>
         public void setScenario(string scenario)
         {
             _currentSceanrio = scenario;
         }
 
+        /// <summary>
+        /// Sets the driver, needed to perform measurements later.
+        /// </summary>
+        /// <param name="driver">The driver to access the browser</param>
         public void setDriver(RemoteWebDriver driver)
         {
             _driver = driver;
         }
 
+        /// <summary>
+        /// Enables the ResponsivenessTimer. After this function is called, measurements will be taken when running scenarios.
+        /// </summary>
         public void enable()
         {
             _enabled = true;
         }
 
-
+        /// <summary>
+        /// Returns all recorded results
+        /// </summary>
+        /// <returns>A list of comma-delimited strings with measurements</returns>
         public List<string> getResults()
         {
             List<string> results = new List<string>();
@@ -78,18 +111,32 @@ namespace BrowserEfficiencyTest
 
         // Functions for scenarios to record responsiveness results:
 
-        public void extractPageLoadTime()
+        /// <summary>
+        /// Records how long the current page took to load (from navigation start to the end of the DOMContentLoaded event).
+        /// </summary>
+        /// <param name="pageLoaded">The name (or other identifier) of the current page. Needed to distinguish multiple page loads in a single scenario.</param>
+        public void extractPageLoadTime(string pageLoaded = null)
         {
             if (_enabled)
             {
                 IJavaScriptExecutor javascriptEngine = _driver as IJavaScriptExecutor;
                 var timeToLoad = javascriptEngine.ExecuteScript("return performance.timing.domContentLoadedEventEnd - performance.timing.navigationStart");
-                makeRecord("Page Load Time (ms)", timeToLoad.ToString());
+                string measureName = "Page Load Time (ms)";
+                if (pageLoaded != null && pageLoaded != "")
+                {
+                    measureName += ": " + pageLoaded;
+                }
+                makeRecord(measureName, timeToLoad.ToString());
             }
         }
 
         // Internal functions:
 
+        /// <summary>
+        /// Records a measurement. Fills in most fields automatically, and so it only needs the measure name and result
+        /// </summary>
+        /// <param name="measure">The measure name</param>
+        /// <param name="result">The result of the measurement</param>
         private void makeRecord(string measure, string result)
         {
             DateTime now = DateTime.Now;

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -37,7 +37,7 @@ namespace BrowserEfficiencyTest
         /// Sets the iteration, which will be included when a measurement is recorded later.
         /// </summary>
         /// <param name="iteration">The current iteration</param>
-        public void setIteration(int iteration)
+        public void SetIteration(int iteration)
         {
             _iteration = iteration;
         }
@@ -46,7 +46,7 @@ namespace BrowserEfficiencyTest
         /// Sets the browser, which will be included when a measurement is recorded later.
         /// </summary>
         /// <param name="browser">The current browser</param>
-        public void setBrowser(string browser)
+        public void SetBrowser(string browser)
         {
             _browser = browser;
         }
@@ -55,7 +55,7 @@ namespace BrowserEfficiencyTest
         /// Sets the measureSet, which will be included when a measurement is recorded later.
         /// </summary>
         /// <param name="measureSet"></param>
-        public void setMeasureSet(string measureSet)
+        public void SetMeasureSet(string measureSet)
         {
             _measureSet = measureSet;
         }
@@ -64,7 +64,7 @@ namespace BrowserEfficiencyTest
         /// Sets the sceanrio, which will be included when a measurement is recorded later.
         /// </summary>
         /// <param name="scenario">The current scenario</param>
-        public void setScenario(string scenario)
+        public void SetScenario(string scenario)
         {
             _currentSceanrio = scenario;
         }
@@ -73,7 +73,7 @@ namespace BrowserEfficiencyTest
         /// Sets the driver, needed to perform measurements later.
         /// </summary>
         /// <param name="driver">The driver to access the browser</param>
-        public void setDriver(RemoteWebDriver driver)
+        public void SetDriver(RemoteWebDriver driver)
         {
             _driver = driver;
         }
@@ -81,7 +81,7 @@ namespace BrowserEfficiencyTest
         /// <summary>
         /// Enables the ResponsivenessTimer. After this function is called, measurements will be taken when running scenarios.
         /// </summary>
-        public void enable()
+        public void Enable()
         {
             _enabled = true;
         }
@@ -90,7 +90,7 @@ namespace BrowserEfficiencyTest
         /// Returns all recorded results
         /// </summary>
         /// <returns>A list of comma-delimited strings with measurements</returns>
-        public List<string> getResults()
+        public List<string> GetResults()
         {
             List<string> results = new List<string>();
             foreach (List<string> result in _results)
@@ -115,7 +115,7 @@ namespace BrowserEfficiencyTest
         /// Records how long the current page took to load (from navigation start to the end of the DOMContentLoaded event).
         /// </summary>
         /// <param name="pageLoaded">The name (or other identifier) of the current page. Needed to distinguish multiple page loads in a single scenario.</param>
-        public void extractPageLoadTime(string pageLoaded = null)
+        public void ExtractPageLoadTime(string pageLoaded = null)
         {
             if (_enabled)
             {

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -10,7 +10,7 @@ namespace BrowserEfficiencyTest
 {
     internal class ResponsivenessTimer
     {
-        private List<MeasureRecord>  _results;
+        private List<List<String>> _results;
         private string _currentSceanrio;
         private int _iteration;
         private string _browser;
@@ -18,35 +18,11 @@ namespace BrowserEfficiencyTest
         private RemoteWebDriver _driver;
         private bool _enabled;
 
-        internal class MeasureRecord
-        {
-            public string EtlName;
-            public string Scenario;
-            public string Iteration;
-            public string Browser;
-            public string Date;
-            public string Time;
-            public string MeasureSet;
-            public string Measure;
-            public string Result;
-
-            public MeasureRecord(string etlName, string scenario, string iteration, string browser, string date, string time, string measureSet, string measure, string result)
-            {
-                EtlName = etlName;
-                Scenario = scenario;
-                Iteration = iteration;
-                Browser = browser;
-                Date = date;
-                Time = time;
-                MeasureSet = measureSet;
-                Measure = measure;
-                Result = result;
-            }
-        }
+        // Functions for test harness:
 
         public ResponsivenessTimer()
         {
-            _results = new List<MeasureRecord>();
+            _results = new List<List<String>>();
             _enabled = false;
         }
 
@@ -80,24 +56,54 @@ namespace BrowserEfficiencyTest
             _enabled = true;
         }
 
-        private void makeRecord(string measure, string result)
+
+        public List<string> getResults()
         {
-            DateTime now = DateTime.Now;
-            MeasureRecord record = new MeasureRecord("no_etl", _currentSceanrio, _iteration.ToString(), _browser, now.ToString("yyyyMMdd"), now.ToString("HHmmss"), "responsiveness (" + _measureSet + ")", measure, result);
-            _results.Add(record);
+            List<string> results = new List<string>();
+            foreach (List<string> result in _results)
+            {
+                string resultString = "";
+                foreach(string component in result)
+                {
+                    if (resultString != "")
+                    {
+                        resultString += ",";
+                    }
+                    resultString += component;
+                }
+                results.Add(resultString);
+            }
+            return results;
         }
 
         // Functions for scenarios to record responsiveness results:
 
-        public void extractPLT()
+        public void extractPageLoadTime()
         {
             if (_enabled)
             {
                 IJavaScriptExecutor javascriptEngine = _driver as IJavaScriptExecutor;
-                var timeToLoad = javascriptEngine.ExecuteScript("return performance.timing.loadEventEnd - performance.timing.navigationStart");
+                var timeToLoad = javascriptEngine.ExecuteScript("return performance.timing.domContentLoadedEventEnd - performance.timing.navigationStart");
                 makeRecord("Page Load Time (ms)", timeToLoad.ToString());
-                Console.WriteLine("Recorded page load time");
             }
+        }
+
+        // Internal functions:
+
+        private void makeRecord(string measure, string result)
+        {
+            DateTime now = DateTime.Now;
+            List<String> record = new List<String>();
+            record.Add("no_etl");
+            record.Add(_currentSceanrio);
+            record.Add(_iteration.ToString());
+            record.Add(_browser);
+            record.Add(now.ToString("yyyyMMdd"));
+            record.Add(now.ToString("HHmmss"));
+            record.Add("responsiveness (" + _measureSet + ")");
+            record.Add(measure);
+            record.Add(result);
+            _results.Add(record);
         }
     }
 }

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -1,0 +1,102 @@
+﻿using OpenQA.Selenium.Remote;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BrowserEfficiencyTest
+{
+    internal class ResponsivenessTimer
+    {
+        private List<MeasureRecord>  _results;
+        private string _currentSceanrio;
+        private int _iteration;
+        private string _browser;
+        private string _measureSet;
+        private RemoteWebDriver _driver;
+        private bool _enabled;
+
+        internal class MeasureRecord
+        {
+            public string EtlName;
+            public string Scenario;
+            public string Iteration;
+            public string Browser;
+            public string Date;
+            public string Time;
+            public string MeasureSet;
+            public string Measure;
+            public string Result;
+
+            public MeasureRecord(string etlName, string scenario, string iteration, string browser, string date, string time, string measureSet, string measure, string result)
+            {
+                EtlName = etlName;
+                Scenario = scenario;
+                Iteration = iteration;
+                Browser = browser;
+                Date = date;
+                Time = time;
+                MeasureSet = measureSet;
+                Measure = measure;
+                Result = result;
+            }
+        }
+
+        public ResponsivenessTimer()
+        {
+            _results = new List<MeasureRecord>();
+            _enabled = false;
+        }
+
+        public void setIteration(int iteration)
+        {
+            _iteration = iteration;
+        }
+
+        public void setBrowser(string browser)
+        {
+            _browser = browser;
+        }
+
+        public void setMeasureSet(string measureSet)
+        {
+            _measureSet = measureSet;
+        }
+
+        public void setScenario(string scenario)
+        {
+            _currentSceanrio = scenario;
+        }
+
+        public void setDriver(RemoteWebDriver driver)
+        {
+            _driver = driver;
+        }
+
+        public void enable()
+        {
+            _enabled = true;
+        }
+
+        private void makeRecord(string measure, int result)
+        {
+            DateTime now = new DateTime();
+            string date = "" + now.Year + now.Month + now.Day;
+            string time = "" + now.Hour + now.Minute + now.Second;
+            MeasureRecord record = new MeasureRecord("no_etl", _currentSceanrio, _iteration.ToString(), _browser, date, time, "responsiveness (" + _measureSet + ")", measure, result.ToString());
+            _results.Add(record);
+        }
+
+        // Functions for scenarios to record responsiveness results:
+
+        public void extractPLT()
+        {
+            if (_enabled)
+            {
+                makeRecord("Page Load Time (ms)", 99);
+                Console.WriteLine("new record created: " + _results[_results.Count - 1].ToString());
+            }
+        }
+    }
+}

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -1,4 +1,5 @@
-﻿using OpenQA.Selenium.Remote;
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -79,12 +80,10 @@ namespace BrowserEfficiencyTest
             _enabled = true;
         }
 
-        private void makeRecord(string measure, int result)
+        private void makeRecord(string measure, string result)
         {
-            DateTime now = new DateTime();
-            string date = "" + now.Year + now.Month + now.Day;
-            string time = "" + now.Hour + now.Minute + now.Second;
-            MeasureRecord record = new MeasureRecord("no_etl", _currentSceanrio, _iteration.ToString(), _browser, date, time, "responsiveness (" + _measureSet + ")", measure, result.ToString());
+            DateTime now = DateTime.Now;
+            MeasureRecord record = new MeasureRecord("no_etl", _currentSceanrio, _iteration.ToString(), _browser, now.ToString("yyyyMMdd"), now.ToString("HHmmss"), "responsiveness (" + _measureSet + ")", measure, result);
             _results.Add(record);
         }
 
@@ -94,8 +93,10 @@ namespace BrowserEfficiencyTest
         {
             if (_enabled)
             {
-                makeRecord("Page Load Time (ms)", 99);
-                Console.WriteLine("new record created: " + _results[_results.Count - 1].ToString());
+                IJavaScriptExecutor javascriptEngine = _driver as IJavaScriptExecutor;
+                var timeToLoad = javascriptEngine.ExecuteScript("return performance.timing.loadEventEnd - performance.timing.navigationStart");
+                makeRecord("Page Load Time (ms)", timeToLoad.ToString());
+                Console.WriteLine("Recorded page load time");
             }
         }
     }

--- a/BrowserEfficiencyTest/ResponsivenessTimer.cs
+++ b/BrowserEfficiencyTest/ResponsivenessTimer.cs
@@ -126,7 +126,7 @@ namespace BrowserEfficiencyTest
                 {
                     measureName += ": " + pageLoaded;
                 }
-                makeRecord(measureName, timeToLoad.ToString());
+                MakeRecord(measureName, timeToLoad.ToString());
             }
         }
 
@@ -137,7 +137,7 @@ namespace BrowserEfficiencyTest
         /// </summary>
         /// <param name="measure">The measure name</param>
         /// <param name="result">The result of the measurement</param>
-        private void makeRecord(string measure, string result)
+        private void MakeRecord(string measure, string result)
         {
             DateTime now = DateTime.Now;
             List<String> record = new List<String>();

--- a/BrowserEfficiencyTest/Scenario.cs
+++ b/BrowserEfficiencyTest/Scenario.cs
@@ -42,6 +42,6 @@ namespace BrowserEfficiencyTest
         public int DefaultDuration { get; set; } = 40;
 
         // Override this function with the "stuff" to do in the scenario
-        public abstract void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager);
+        public abstract void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer);
     }
 }

--- a/BrowserEfficiencyTest/ScenarioRunner.cs
+++ b/BrowserEfficiencyTest/ScenarioRunner.cs
@@ -137,7 +137,7 @@ namespace BrowserEfficiencyTest
 
             if (_useTimer)
             {
-                _timer.enable();
+                _timer.Enable();
             }
 
             RunMainLoop();
@@ -145,7 +145,7 @@ namespace BrowserEfficiencyTest
 
         public List<string> getResponsivnessResults()
         {
-            return _timer.getResults();
+            return _timer.GetResults();
         }
 
         private void RunWarmupPass()
@@ -198,10 +198,10 @@ namespace BrowserEfficiencyTest
                 // TODO: Consider breaking up this large loop into smaller methods to ease readability.
                 for (int iteration = 0; iteration < _iterations; iteration++)
                 {
-                    _timer.setIteration(iteration);
+                    _timer.SetIteration(iteration);
                     foreach (var currentMeasureSet in _measureSets)
                     {
-                        _timer.setMeasureSet(currentMeasureSet.Key);
+                        _timer.SetMeasureSet(currentMeasureSet.Key);
 
                         // Randomize the order the browsers each iteration to reduce systematic bias in the test
                         Random rand = new Random();
@@ -209,7 +209,7 @@ namespace BrowserEfficiencyTest
 
                         foreach (string browser in _browsers)
                         {
-                            _timer.setBrowser(browser);
+                            _timer.SetBrowser(browser);
 
                             bool passSucceeded = false;
                             for (int attemptNumber = 0; attemptNumber < _maxAttempts && !passSucceeded; attemptNumber++)
@@ -229,11 +229,11 @@ namespace BrowserEfficiencyTest
                                         Stopwatch watch = Stopwatch.StartNew();
                                         bool isFirstScenario = true;
 
-                                        _timer.setDriver(driver);
+                                        _timer.SetDriver(driver);
 
                                         foreach (var scenario in _scenarios)
                                         {
-                                            _timer.setScenario(scenario.ScenarioName);
+                                            _timer.SetScenario(scenario.ScenarioName);
 
                                             // We want every scenario to take the same amount of time total, even if there are changes in
                                             // how long pages take to load. The biggest reason for this is so that you can measure energy

--- a/BrowserEfficiencyTest/ScenarioRunner.cs
+++ b/BrowserEfficiencyTest/ScenarioRunner.cs
@@ -143,7 +143,7 @@ namespace BrowserEfficiencyTest
             RunMainLoop();
         }
 
-        public List<string> getResponsivnessResults()
+        public List<string> GetResponsivenessResults()
         {
             return _timer.GetResults();
         }

--- a/BrowserEfficiencyTest/ScenarioRunner.cs
+++ b/BrowserEfficiencyTest/ScenarioRunner.cs
@@ -143,6 +143,11 @@ namespace BrowserEfficiencyTest
             RunMainLoop();
         }
 
+        public List<string> getResponsivnessResults()
+        {
+            return _timer.getResults();
+        }
+
         private void RunWarmupPass()
         {
             // A warmup pass is one run thru the selected scenarios and browsers.

--- a/BrowserEfficiencyTest/Scenarios/AboutBlank.cs
+++ b/BrowserEfficiencyTest/Scenarios/AboutBlank.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("about:blank");
         }

--- a/BrowserEfficiencyTest/Scenarios/AmazonSearch.cs
+++ b/BrowserEfficiencyTest/Scenarios/AmazonSearch.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 45;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Navigate
             driver.Navigate().GoToUrl("http://www.amazon.com");

--- a/BrowserEfficiencyTest/Scenarios/AzureDashboard.cs
+++ b/BrowserEfficiencyTest/Scenarios/AzureDashboard.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 120;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Get the relevant username and password
             UserInfo credentials = credentialManager.GetCredentials("azure.com");

--- a/BrowserEfficiencyTest/Scenarios/BbcNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/BbcNews.cs
@@ -42,7 +42,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Navigate
             driver.Navigate().GoToUrl("http://www.bbc.com");

--- a/BrowserEfficiencyTest/Scenarios/BbcNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/BbcNews.cs
@@ -49,6 +49,8 @@ namespace BrowserEfficiencyTest
             driver.WaitForPageLoad();
             driver.Wait(10);
 
+            timer.extractPageLoadTime("BBC homepage");
+
             // Navigate to the hero headline
             driver.ClickElement(driver.FindElement(By.XPath("//*[@rev='hero1|headline']")));
 
@@ -57,6 +59,8 @@ namespace BrowserEfficiencyTest
             driver.ScrollPage(2);
             driver.Wait(2);
             driver.ScrollPage(2);
+
+            timer.extractPageLoadTime("BBC article");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/BbcNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/BbcNews.cs
@@ -49,7 +49,7 @@ namespace BrowserEfficiencyTest
             driver.WaitForPageLoad();
             driver.Wait(10);
 
-            timer.extractPageLoadTime("BBC homepage");
+            timer.ExtractPageLoadTime("BBC homepage");
 
             // Navigate to the hero headline
             driver.ClickElement(driver.FindElement(By.XPath("//*[@rev='hero1|headline']")));
@@ -60,7 +60,7 @@ namespace BrowserEfficiencyTest
             driver.Wait(2);
             driver.ScrollPage(2);
 
-            timer.extractPageLoadTime("BBC article");
+            timer.ExtractPageLoadTime("BBC article");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/CnnOneStory.cs
+++ b/BrowserEfficiencyTest/Scenarios/CnnOneStory.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             Name = "CnnOneStory";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://bleacherreport.com/articles/2657513-tim-duncan-declined-olympic-invitation-from-president-obama?utm_source=cnn.com&utm_medium=referral&utm_campaign=editorial");
         }

--- a/BrowserEfficiencyTest/Scenarios/CnnTopStory.cs
+++ b/BrowserEfficiencyTest/Scenarios/CnnTopStory.cs
@@ -43,7 +43,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 90;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             IWebElement headlineElement = null;
 

--- a/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
+++ b/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
@@ -51,7 +51,7 @@ namespace BrowserEfficiencyTest
             // Scroll through the infinite list
             driver.ScrollPage(20);
 
-            timer.extractPageLoadTime("ESPN homepage");
+            timer.ExtractPageLoadTime("ESPN homepage");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
+++ b/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 75;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to espn
             driver.Navigate().GoToUrl("http://www.espn.com");

--- a/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
+++ b/BrowserEfficiencyTest/Scenarios/EspnHomepage.cs
@@ -50,6 +50,8 @@ namespace BrowserEfficiencyTest
 
             // Scroll through the infinite list
             driver.ScrollPage(20);
+
+            timer.extractPageLoadTime("ESPN homepage");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
+++ b/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.facebook.com");
             driver.WaitForPageLoad();

--- a/BrowserEfficiencyTest/Scenarios/FastScenario.cs
+++ b/BrowserEfficiencyTest/Scenarios/FastScenario.cs
@@ -45,7 +45,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 10;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.google.com");
         }

--- a/BrowserEfficiencyTest/Scenarios/GmailGoThroughEmails.cs
+++ b/BrowserEfficiencyTest/Scenarios/GmailGoThroughEmails.cs
@@ -89,7 +89,7 @@ namespace BrowserEfficiencyTest
             driver.Wait(7);
 
             // Check the url to make sure login was successful
-            if(driver.Url != @"https://mail.google.com/mail/u/0/#inbox")
+            if(driver.Url != @"https://mail.google.com/mail/u/0/#inbox" && driver.Url != @"https://mail.google.com/mail/#inbox")
             {
                 throw new Exception("Login to Gmail failed!");
             }

--- a/BrowserEfficiencyTest/Scenarios/GmailGoThroughEmails.cs
+++ b/BrowserEfficiencyTest/Scenarios/GmailGoThroughEmails.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 80;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             NavigateToGmail(driver);
             driver.Wait(2);

--- a/BrowserEfficiencyTest/Scenarios/GoogleSearch.cs
+++ b/BrowserEfficiencyTest/Scenarios/GoogleSearch.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             // Default time
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.google.com");
             driver.WaitForPageLoad();

--- a/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
+++ b/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
@@ -57,7 +57,7 @@ namespace BrowserEfficiencyTest
             // Then scroll through it
             driver.ScrollPage(8);
 
-            timer.extractPageLoadTime("Instagram account");
+            timer.ExtractPageLoadTime("Instagram account");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
+++ b/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
@@ -57,7 +57,7 @@ namespace BrowserEfficiencyTest
             // Then scroll through it
             driver.ScrollPage(8);
 
-            timer.extractPageLoadTime();
+            timer.extractPageLoadTime("Instagram account");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
+++ b/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to the Instagram page for the NY public library
             driver.Navigate().GoToUrl("https://www.instagram.com/nypl/");

--- a/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
+++ b/BrowserEfficiencyTest/Scenarios/InstagramNYPL.cs
@@ -56,6 +56,8 @@ namespace BrowserEfficiencyTest
 
             // Then scroll through it
             driver.ScrollPage(8);
+
+            timer.extractPageLoadTime();
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/LinkedInSatya.cs
+++ b/BrowserEfficiencyTest/Scenarios/LinkedInSatya.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             Name = "LinkedInSatya";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to the public page for Satya Nadella
             driver.Navigate().GoToUrl("https://www.linkedin.com/in/satya-nadella-3145136");

--- a/BrowserEfficiencyTest/Scenarios/Msn.cs
+++ b/BrowserEfficiencyTest/Scenarios/Msn.cs
@@ -38,7 +38,7 @@ namespace BrowserEfficiencyTest
             Name = "Msn";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.msn.com");
             driver.Wait(20);

--- a/BrowserEfficiencyTest/Scenarios/Msnbc.cs
+++ b/BrowserEfficiencyTest/Scenarios/Msnbc.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             Name = "Msnbc";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.msnbc.com");
             driver.ScrollPage(5);

--- a/BrowserEfficiencyTest/Scenarios/OfficeLauncher.cs
+++ b/BrowserEfficiencyTest/Scenarios/OfficeLauncher.cs
@@ -38,7 +38,7 @@ namespace BrowserEfficiencyTest
             Name = "OfficeLauncher";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             UserInfo credentials = credentialManager.GetCredentials("office.com");
 

--- a/BrowserEfficiencyTest/Scenarios/OfficePowerpoint.cs
+++ b/BrowserEfficiencyTest/Scenarios/OfficePowerpoint.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             UserInfo credentials = credentialManager.GetCredentials("office.com");
 

--- a/BrowserEfficiencyTest/Scenarios/OutlookEmail.cs
+++ b/BrowserEfficiencyTest/Scenarios/OutlookEmail.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 100;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             UserInfo credentials = credentialManager.GetCredentials("outlook.com");
 

--- a/BrowserEfficiencyTest/Scenarios/OutlookOffice.cs
+++ b/BrowserEfficiencyTest/Scenarios/OutlookOffice.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 80;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             UserInfo credentials = credentialManager.GetCredentials("outlook.com");
 

--- a/BrowserEfficiencyTest/Scenarios/PinterestExplore.cs
+++ b/BrowserEfficiencyTest/Scenarios/PinterestExplore.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             UserInfo credentials = credentialManager.GetCredentials("pinterest.com");
 

--- a/BrowserEfficiencyTest/Scenarios/PowerBIBrowse.cs
+++ b/BrowserEfficiencyTest/Scenarios/PowerBIBrowse.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 70;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Get the relevant username and password
             UserInfo credentials = credentialManager.GetCredentials("powerbi.com");

--- a/BrowserEfficiencyTest/Scenarios/TechRadarSurfacePro4Review.cs
+++ b/BrowserEfficiencyTest/Scenarios/TechRadarSurfacePro4Review.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(30));
 

--- a/BrowserEfficiencyTest/Scenarios/TumblrTrending.cs
+++ b/BrowserEfficiencyTest/Scenarios/TumblrTrending.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to the homepage for Tumblr
             driver.Navigate().GoToUrl("https://www.tumblr.com/explore/trending");

--- a/BrowserEfficiencyTest/Scenarios/TwitterPublic.cs
+++ b/BrowserEfficiencyTest/Scenarios/TwitterPublic.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 60;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to the homepage for Twitter
             driver.Navigate().GoToUrl("https://www.twitter.com");

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -56,7 +56,7 @@ namespace BrowserEfficiencyTest
             // Scroll a bit
             driver.ScrollPage(12);
 
-            timer.extractPLT();
+            timer.extractPageLoadTime();
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -56,7 +56,7 @@ namespace BrowserEfficiencyTest
             // Scroll a bit
             driver.ScrollPage(12);
 
-            timer.extractPageLoadTime();
+            timer.extractPageLoadTime("Wikipedia article");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -55,6 +55,8 @@ namespace BrowserEfficiencyTest
 
             // Scroll a bit
             driver.ScrollPage(12);
+
+            timer.extractPLT();
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -56,7 +56,7 @@ namespace BrowserEfficiencyTest
             // Scroll a bit
             driver.ScrollPage(12);
 
-            timer.extractPageLoadTime("Wikipedia article");
+            timer.ExtractPageLoadTime("Wikipedia article");
         }
     }
 }

--- a/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
+++ b/BrowserEfficiencyTest/Scenarios/WikipediaUnitedStates.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             Name = "WikipediaUnitedStates";
             DefaultDuration = 30;
         }
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to Wikipedia/United_States
             driver.Navigate().GoToUrl("https://en.wikipedia.org/wiki/United_States");

--- a/BrowserEfficiencyTest/Scenarios/YahooNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/YahooNews.cs
@@ -47,6 +47,8 @@ namespace BrowserEfficiencyTest
             driver.WaitForPageLoad();
             driver.Wait(5);
 
+            timer.extractPageLoadTime("Yahoo homepage");
+
             IWebElement newsLink;
             // Go to the News section
             // There are a number of different layouts currently.  Trying each one in order of observed probability.
@@ -94,6 +96,8 @@ namespace BrowserEfficiencyTest
             driver.Wait(6);
             driver.ScrollPage(1);
             driver.Wait(6);
+
+            timer.extractPageLoadTime("Yahoo article");
 
             // Then go back to the news homepage
             driver.Navigate().Back();

--- a/BrowserEfficiencyTest/Scenarios/YahooNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/YahooNews.cs
@@ -47,7 +47,7 @@ namespace BrowserEfficiencyTest
             driver.WaitForPageLoad();
             driver.Wait(5);
 
-            timer.extractPageLoadTime("Yahoo homepage");
+            timer.ExtractPageLoadTime("Yahoo homepage");
 
             IWebElement newsLink;
             // Go to the News section
@@ -97,7 +97,7 @@ namespace BrowserEfficiencyTest
             driver.ScrollPage(1);
             driver.Wait(6);
 
-            timer.extractPageLoadTime("Yahoo article");
+            timer.ExtractPageLoadTime("Yahoo article");
 
             // Then go back to the news homepage
             driver.Navigate().Back();

--- a/BrowserEfficiencyTest/Scenarios/YahooNews.cs
+++ b/BrowserEfficiencyTest/Scenarios/YahooNews.cs
@@ -41,7 +41,7 @@ namespace BrowserEfficiencyTest
             DefaultDuration = 90;
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             driver.Navigate().GoToUrl("http://www.yahoo.com");
             driver.WaitForPageLoad();

--- a/BrowserEfficiencyTest/Scenarios/YelpSeattleDinner.cs
+++ b/BrowserEfficiencyTest/Scenarios/YelpSeattleDinner.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             Name = "YelpSeattleDinner";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to Yelp (Seattle)
             driver.Navigate().GoToUrl("http://yelp.com/seattle");

--- a/BrowserEfficiencyTest/Scenarios/YoutubeWatchVideo.cs
+++ b/BrowserEfficiencyTest/Scenarios/YoutubeWatchVideo.cs
@@ -39,7 +39,7 @@ namespace BrowserEfficiencyTest
             // Leave the default time
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Browse to Youtube if we're not there already
             if (!driver.Url.Contains("youtube.com"))

--- a/BrowserEfficiencyTest/Scenarios/ZillowSearch.cs
+++ b/BrowserEfficiencyTest/Scenarios/ZillowSearch.cs
@@ -40,7 +40,7 @@ namespace BrowserEfficiencyTest
             Name = "ZillowSearch";
         }
 
-        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager)
+        public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
             // Nagivate to zillow, direct to a results page
             driver.Navigate().GoToUrl("http://www.zillow.com/homes/98052_rb/?fromHomePage=true&shouldFireSellPageImplicitClaimGA=false");

--- a/BrowserEfficiencyTest/workloads.json
+++ b/BrowserEfficiencyTest/workloads.json
@@ -99,5 +99,19 @@
         "Tab": "new"
       }
     ]
+  },
+
+    {
+    "Name": "simple",
+    "Scenarios": [
+      {
+        "ScenarioName": "WikipediaUnitedStates",
+        "Tab": "new"
+      },
+      {
+        "ScenarioName": "GoogleSearch",
+        "Tab": "new"
+      }
+    ]
   }
 ]

--- a/Documentation/GetStarted.md
+++ b/Documentation/GetStarted.md
@@ -92,7 +92,9 @@ The items in this section are not required, but they are useful recommendations 
 
 ## Run the test
 
-### Start Elevator
+### Start Elevator first
+
+> This step is only necessary if you're using tracing for any of your measures. This is the case if you're providing the "-ms" or "-measureset" flag in the next step. Both the examples below do require this.
 
 * Run Elevator by going to the its folder, then within it, navigating to \ElevatorServer\bin\Debug\ElevatorServer.exe (assuming you built for Debug).
 * Accept the UAC prompt
@@ -106,18 +108,21 @@ The items in this section are not required, but they are useful recommendations 
 
 #### Fast test run
 
-To ensure your configuration and build is correct, here's a good test to run. It will run through each browser twice, using two quick scenarios in two different tabs, and record how much CPU was used for them:
+To ensure your configuration and build is correct, here's a good test to run. It will run through two browsers twice each, using two quick scenarios in two different tabs, and record how much CPU was used for them:
 
 You'll have to provide a path to place the resulting traces after the `-tc` command. Remember that this also assumes Elevator is already running and waiting for a client connection.
 
 ```
-> BrowserEfficiencyTest.exe -b edge chrome opera firefox -i 2 -tc C:\Some\Path\TestTraces -ms cpuUsage -s FastScenario WikipediaUnitedStates
+> BrowserEfficiencyTest.exe -b edge chrome -i 2 -rp C:\Some\Path\TestTraces -ms cpuUsage -s FastScenario WikipediaUnitedStates
 ```
 
 #### Full test run
 
-To get a full 5 iterations on each browser running a default set of scenarios, use a workload instead of individual scenarios. These workloads are defined in `workloads.json`.
+To get a full 5 iterations on each browser running a default set of scenarios, use a workload instead of individual scenarios. These workloads are defined in `workloads.json`. This configuration will also record page load times for the scenarios that specify it.
 
 ```
-> BrowserEfficiencyTest.exe -b edge chrome opera firefox -i 5 -tc C:\Some\Path\TestTraces -ms cpuUsage -w representative
+> BrowserEfficiencyTest.exe -b edge chrome -i 5 -rp C:\Some\Path\TestTraces -ms cpuUsage -w representative -r
 ```
+### See results
+
+Go to the path you specified after `-rp` (results path). You should now see a number of traces equal to the number of browsers * the number of iterations * the number of measure sets provided. You should also see a CSV file with all the results in it. The CSV will include results from all of those traces in one convenient place.

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-BrowserEfficiencyTest is best run from the command line, and requires an instance of [Elevator](https://github.com/MicrosoftEdge/Elevator) running if you use `-tracecontrolled|-tc` and `-measureset|-ms`.
+BrowserEfficiencyTest is best run from the command line, and requires an instance of [Elevator](https://github.com/MicrosoftEdge/Elevator) running if you use  `-measureset` or `-ms`.
 
 > **WARNING**
 > When run on Microsoft Edge, this will delete browser data, including history, saved passwords, and form fill.
@@ -10,7 +10,7 @@ BrowserEfficiencyTest is best run from the command line, and requires an instanc
 Usage:
 
 ```
-BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-workload|-w <workload name>]|[-scenario|-s <scenario1> <scenario2>]] [-iterations|-i <iterationcount>] [-tracecontrolled|-tc <etlpath> -measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np] [-credentialpath|-cp <path to credentials json file>]
+BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-workload|-w <workload name>]|[-scenario|-s <scenario1> <scenario2>]] [-iterations|-i <iterationcount>] [-resultspath|-rp <etlpath>] [-measureset|-ms <measureset1> <measureset2>] [-warmup] [-profile|-p <chrome profile path>] [-attempts|-a <attempts to make per iteration>] [-notimeout] [-noprocessing|-np] [-credentialpath|-cp <path to credentials json file>] [-responsiveness|-r]
 ```
 
 *   **-browser|-b** Selects the browser or browsers to run the scenarios with. This option must be provided. Multiple browsers can be selected by separating each browser with a space. E.g. `-b edge chrome`. The possible options are:
@@ -23,6 +23,7 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-w
 
     *   `representative` This workload runs through 12 common sites across 4 tabs, spending a minute and a half on each one, with some meaningful interaction with each of them. This workload takes 18 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook and Gmail.
     *   `heavymultitab` This workload runs through 8 sites all in different tabs, with interaction on each of them. It represents heavy usage of the browser especially across many tabs. It takes about 8 minutes to complete and requires credentials to be specified in `credentials.json` for Facebook and Gmail.
+    *   `simple` This is a simple workload that finishes quickly for testing purposes. It does not require any credentials.
 
 *   **-scenario|-s** Selects the scenario or scenarios to run. This option must be provided unless a workload is provided instead. Multiple scenarios can be selected by separating each scenario with a space. Scenario names are not case sensitive. E.g. `-s wikipedia gmail facebook`. When multiple scenarios are selected, they will all be run on every browser, in the order they were provided, all in different tabs. When a scenario completes and there's additional scenarios after it, it will be left running in a background tab. The possible options are:
 
@@ -30,14 +31,17 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-w
     *   `AmazonSearch` will load Amazon, do a search for "game of thrones", click on the first result, and then scroll down to the reviews
     *   `AzureDashboard` will load an Azure dashboard for the provided credentials and navigate through several blades. It requires Azure credentials to be provided in `credentials.json`
     *   `BbcNews` will load BBC, click on the top story, and scroll down
+        *   Responsiveness measures: Homepage load time, article load time
     *   `CnnOneStory` will directly load a news story from CNN, but not interact with CNN besides the page load
     *   `CnnTopStory` will load CNN, load the top story, and scroll down
     *   `EspnHomepage` will load ESPN and scroll through the infinite list on the homepage
+        *   Responsiveness measures: ESPN homepage load time
     *   `FacebookNewsfeedScroll` will log into facebook with the provided credentials, and scroll through the news feed. Requires facebook credentials to be provided in the `credentials.json` file
     *   `FastScenario` will load google and quickly exit. This is designed to be fast, and is for testing BrowserEfficiencyTest
     *   `GmailGoThroughEmails` will load Gmail, and scroll through 5 emails in the inbox. Requires gmail credentials to be provided in the `credentials.json` file
     *   `GoogleSearch` will navigate to google.com and then search for "Seattle". It sees the results of the search, but doesn't navigate to any of them
     *   `InstagramNYPL` will load up the public feed for the NY public library, scroll down, click on "Load more", then scroll through the infinite list
+        *   Responsiveness measures: Page load time
     *   `LinkedInSatya` will load the LinkedIn profile for Satya Nadella
     *   `Msn` will navigate to MSN
     *   `Msnbc` will navigate to MSNBC
@@ -51,7 +55,9 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-w
     *   `TumblrTrending` will navigate to tumblr.com, click on "staff picks", then click on "trending", before scrolling through the trending posts
     *   `TwitterPublic` will navigate to twitter and scroll through the featured posts on the homepage
     *   `WikipediaUnitedStates` will navigate to the Wikipedia article on the United States and scroll
-    *   `YahooNews` will navigate to Yahoo.com, go to news, and navigate to the top story. It will then scroll through it before going back to the listing of all news.
+        *   Responsiveness measures: Article page load time
+    *   `YahooNews` will navigate to Yahoo.com, go to news, and navigate to a story (the story is injected by Javascript so it will always navigate to the same one). It will then scroll through it before going back to the listing of all news.
+        *   Responsivenss measures: Homepage load time, article page load time
     *   `YelpSeattleDinner` will navigate to Yelp, search for a restaurant, and click into it
     *   `YoutubeWatchVideo` will play the video "Microsoft Design: Connecting Makers" on Youtube
     *   `ZillowSearch` will load a map of places for sale, expand the map view, then load the top listing
@@ -86,6 +92,8 @@ BrowserEfficiencyTest.exe [-browser|-b [chrome|edge|firefox|opera|operabeta] [-w
 *   **-noprocessing|-np** Allows the test to run without post processing the results at the end of the test. Use this flag with the `-tracecontrolled|-tc` and `-measureset|-ms` options to collect trace files for the specified measureset but skip post processing of the results after the test completes. This is useful where you want to run the test and collect etl traces but want to process the results separately at a later time.
 
 *   **-credentialpath|-cp** Allows a path to be specified that points to a different credentials.json file. An absolute or a relative path can be provided, though the path cannot contain any spaces.
+
+*   **-responsiveness|-r** Records all responsiveness measures specified by the scenarios (e.g. page load time). These will be included in the resulting CSV when the run is complete.
 
 ## Examples
 

--- a/PerfProcessor/PerfProcessor.cs
+++ b/PerfProcessor/PerfProcessor.cs
@@ -72,7 +72,8 @@ namespace BrowserEfficiencyTest
         /// </summary>
         /// <param name="etlFolderPath">Location of the ETL files to process the performance data from.</param>
         /// <param name="saveFolderPath">Location of where to save the results csv file.</param>
-        public void Execute(string etlFolderPath = ".", string saveFolderPath = "")
+        /// <param name="resultsToAdd">Any already-measured results to include in the csv file</param>
+        public void Execute(string etlFolderPath = ".", string saveFolderPath = "", List<string> resultsToAdd = null)
         {
             Dictionary<string, Dictionary<string, Dictionary<string, string>>> results = null;
             List<string> formattedResults = null;
@@ -83,6 +84,14 @@ namespace BrowserEfficiencyTest
             results = ProcessEtls(etlFiles);
 
             formattedResults = FormatResults(results);
+
+            if (resultsToAdd != null)
+            {
+                foreach (string result in resultsToAdd)
+                {
+                    formattedResults.Add(result);
+                }
+            }
 
             SaveResults(formattedResults, saveFolderPath);
         }
@@ -98,7 +107,7 @@ namespace BrowserEfficiencyTest
 
             if (etlFiles.Count() == 0)
             {
-                Console.WriteLine("No ETL files were found! Unable to process performance metrics.");
+                Console.WriteLine("No ETL files were found. No trace-based results have been measured.");
                 return null;
             }
 
@@ -145,12 +154,12 @@ namespace BrowserEfficiencyTest
             string metricName = "";
             string metricValue = "";
 
+            formattedData.Add(headerRow);
+
             if (results == null)
             {
-                return null;
+                return formattedData;
             }
-
-            formattedData.Add(headerRow);
 
             // The results data format is Dictionary< "ETL File name" , Dictionary< "measure set name" , Dictionary< "metric name" , "metric value" >>>
             foreach (var etl in results)

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0")]
+[assembly: AssemblyVersion("7.0")]


### PR DESCRIPTION
Responsiveness measures are a new capability of BET. With these, scenarios can specify user-facing measures like page load time that will be recorded along with resource consumption measures collected via tracing. As part of this change, page load time was added to BBC, Yahoo, ESPN, Wikipedia, and Instagram.

Additionally, -tracecontrolled has been renamed to -resultspath, and it's no longer required iff -measureset is provided. Both flags can now be used independently of each other.