### PR TITLE
Look up measureSets using toLowerInvariant

### DIFF
--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -98,7 +98,7 @@ namespace BrowserEfficiencyTest
             _possibleScenarios = new Dictionary<string, WorkloadScenario>();
             _scenarios = new List<WorkloadScenario>();
             _browsers = new List<string>();
-            _availableMeasureSets = PerfProcessor.AvailableMeasureSets.ToDictionary(k => k.Key, v => v.Value);
+            _availableMeasureSets = PerfProcessor.AvailableMeasureSets.ToDictionary(k => k.Key.ToLowerInvariant(), v => v.Value);
             _selectedMeasureSets = new List<MeasureSet>();
             _workloads = new List<Workload>();
 


### PR DESCRIPTION
Without this change, the steps described in [Get Started](https://github.com/MicrosoftEdge/BrowserEfficiencyTest/blob/master/Documentation/GetStarted.md) don't work because it fails to find a measure set by the name of `cpuUsage` because it compares the lowercased version to the non-lowercased version.