### PR TITLE
Fixed issue with getting MicrosoftWebDriver.exe version.

### DIFF
--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("11.1")]
+[assembly: AssemblyVersion("11.2")]

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("11.1")]
+[assembly: AssemblyVersion("11.2")]


### PR DESCRIPTION
This fixes issue #90 where GetFileInfo is unable to find MicrosoftWebDriver.exe. Now BrowserEfficiencyTest uses the webdriver status command to get the version of MicrosoftWebDriver.exe.