### PR TITLE
Added 'season 1' to the search text in the AmazonSearch scenario to f…

### DIFF
--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("17.1")]
+[assembly: AssemblyVersion("17.2")]

--- a/BrowserEfficiencyTest/Scenarios/AmazonSearch.cs
+++ b/BrowserEfficiencyTest/Scenarios/AmazonSearch.cs
@@ -47,11 +47,11 @@ namespace BrowserEfficiencyTest
             driver.NavigateToUrl("https://www.amazon.com");
             driver.Wait(5);
 
-            ScenarioEventSourceProvider.EventLog.ScenarioActionStart("Search for 'Game of Thrones'");
-            // Type "Game of Thrones" in the search box and hit enter
-            driver.TypeIntoField(driver.FindElementById("twotabsearchtextbox"), "Game of Thrones" + Keys.Enter);
+            ScenarioEventSourceProvider.EventLog.ScenarioActionStart("Search for 'Game of Thrones Season 1'");
+            // Type "Game of Thrones Season 1" in the search box and hit enter
+            driver.TypeIntoField(driver.FindElementById("twotabsearchtextbox"), "Game of Thrones Season 1" + Keys.Enter);
             driver.Wait(5);
-            ScenarioEventSourceProvider.EventLog.ScenarioActionStop("Search for 'Game of Thrones'");
+            ScenarioEventSourceProvider.EventLog.ScenarioActionStop("Search for 'Game of Thrones Season 1'");
 
             ScenarioEventSourceProvider.EventLog.ScenarioActionStart("Click on 'Game of Thrones Season 1'");
             // Click into "Game of Thrones Season 1"

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("17.1")]
+[assembly: AssemblyVersion("17.2")]


### PR DESCRIPTION
…ix issue where 'Game of Thrones Season 1' is no longer on first page after search.