### PR TITLE
Fixes for Facebook and Twitter scenarios

### DIFF
--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("17.3")]
+[assembly: AssemblyVersion("18.0")]

--- a/BrowserEfficiencyTest/Scenarios/TwitterPublic.cs
+++ b/BrowserEfficiencyTest/Scenarios/TwitterPublic.cs
@@ -43,9 +43,14 @@ namespace BrowserEfficiencyTest
 
         public override void Run(RemoteWebDriver driver, string browser, CredentialManager credentialManager, ResponsivenessTimer timer)
         {
-            // Nagivate to the homepage for Twitter
-            driver.NavigateToUrl("https://www.twitter.com");
+            // Nagivate to the Microsoft Twitter page
+            driver.NavigateToUrl("https://twitter.com/microsoft");
             driver.Wait(5);
+
+            // On the first navigation to the page on a new device or after clearing the cookies, Twitter will open the login dropdown window.
+            // Sending the keyboard escape key clears this and allows us to continue scrolling on the page.
+            driver.SendKeys(Keys.Escape);
+            driver.Wait(1);
 
             ScenarioEventSourceProvider.EventLog.ScenarioActionStart("Scroll down page");
             // Scroll through the infinite list

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("17.3")]
+[assembly: AssemblyVersion("18.0")]


### PR DESCRIPTION
Facebook now opens a notification request window upon first login on a new device or if cookies have been deleted. This fix looks for this window and will click on the 'Not Now' button if it is detected.

The Twitter public page no longer shows random public tweets that can be scrolled. Instead, it redirects to a login screen. The fix is to now navigate to the Microsoft Twitter page which is open to the public to scroll through.