### PR TITLE
Updated to Selenium Webdriver 3.13.0.

### DIFF
--- a/BrowserEfficiencyTest/BrowserEfficiencyTest.csproj
+++ b/BrowserEfficiencyTest/BrowserEfficiencyTest.csproj
@@ -55,13 +55,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.3.0\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.13.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.3.0\lib\net40\WebDriver.Support.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver.Support, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.13.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
+++ b/BrowserEfficiencyTest/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("19.2")]
+[assembly: AssemblyVersion("20.0")]

--- a/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
+++ b/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
@@ -342,8 +342,6 @@ namespace BrowserEfficiencyTest
                     break;
                 default:
                     EdgeOptions edgeOptions = new EdgeOptions();
-                    edgeOptions.AddAdditionalCapability("browserName", "Microsoft Edge");
-
                     EdgeDriverService edgeDriverService = null;
 
                     if (extensionPaths != null && extensionPaths.Count != 0)

--- a/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
+++ b/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
@@ -408,9 +408,8 @@ namespace BrowserEfficiencyTest
                     _edgeBrowserBuildNumber = GetEdgeBuildNumber(driver);
                     Logger.LogWriteLine(string.Format("   Browser Version - MicrosoftEdge Build Version: {0}", _edgeBrowserBuildNumber));
 
-                    string webDriverServerVersion = GetEdgeWebDriverVersion(driver);
-                    Logger.LogWriteLine(string.Format("   WebDriver Server Version - MicrosoftWebDriver.exe File Version: {0}", webDriverServerVersion));
-                    _edgeWebDriverBuildNumber = Convert.ToInt32(webDriverServerVersion.Split('.')[2]);
+                    _edgeWebDriverBuildNumber = GetEdgeWebDriverVersion(driver);
+                    Logger.LogWriteLine(string.Format("   WebDriver Server Version - MicrosoftWebDriver.exe File Version: {0}", _edgeWebDriverBuildNumber));
 
                     break;
             }
@@ -503,11 +502,24 @@ namespace BrowserEfficiencyTest
         }
 
         // Retrieves the WebDriver server version
-        private static string GetEdgeWebDriverVersion(this RemoteWebDriver remoteWebDriver)
+        private static int GetEdgeWebDriverVersion(this RemoteWebDriver remoteWebDriver)
         {
             var statusResponse = Newtonsoft.Json.Linq.JObject.Parse(CallStatusCommand(remoteWebDriver).Result);
-            string webDriverVersion = (string)statusResponse["value"]["build"]["version"];
+            int webDriverVersion = 0;
 
+            try
+            {
+                string webDriverVersionString = (string)statusResponse["value"]["build"]["version"];
+                webDriverVersion = Convert.ToInt32(webDriverVersionString.Split('.')[2]);
+            }
+            catch (System.NullReferenceException)
+            {
+                // Newer versions of MicrosoftWebDriver.exe (RS4 and later) default to the W3C WebDriver spec which does not return
+                // the webdriver build number in the response to the status command. However, since this happens in RS4 and later builds
+                // we can safely assume the newTab command is supported since the newTab command is in RS3 16203 builds and higher.
+                // So let's set the webDriverVersion to an arbitrary number that is larger than 16203.
+                webDriverVersion = 99999;
+            }
             return webDriverVersion;
         }
 

--- a/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
+++ b/BrowserEfficiencyTest/RemoteWebDriverExtension.cs
@@ -159,6 +159,10 @@ namespace BrowserEfficiencyTest
             // Page down seemed to be the best compromise in terms of it behaving like a real user scrolling, and it
             // working reliably across browsers.
             // Use the page down key.
+
+            var userAction = new OpenQA.Selenium.Interactions.Actions(remoteWebDriver);
+            userAction.SendKeys(Keys.PageDown);
+
             for (int i = 0; i < timesToScroll; i++)
             {
                 ScenarioEventSourceProvider.EventLog.ScrollEvent();
@@ -170,16 +174,14 @@ namespace BrowserEfficiencyTest
                 }
                 else
                 {
-                    remoteWebDriver.Keyboard.SendKeys(Keys.PageDown);
+                    userAction.Perform();
                 }
-
                 Thread.Sleep(1000);
             }
         }
 
         /// <summary>
         /// Sends keystrokes to the browser. Not to a specific element.
-        /// Wrapper for driver.Keyboard.SendKeys(...)
         /// </summary>
         /// <param name="keys">Keystrokes to send to the browser.</param>
         public static void SendKeys(this RemoteWebDriver remoteWebDriver, string keys)
@@ -194,7 +196,8 @@ namespace BrowserEfficiencyTest
             }
             else
             {
-                remoteWebDriver.Keyboard.SendKeys(keys);
+                var userAction = new OpenQA.Selenium.Interactions.Actions(remoteWebDriver);
+                userAction.SendKeys(keys).Perform();
             }
             ScenarioEventSourceProvider.EventLog.SendKeysStop(keys.Length);
         }

--- a/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
+++ b/BrowserEfficiencyTest/Scenarios/FacebookNewsfeedScroll.cs
@@ -69,7 +69,7 @@ namespace BrowserEfficiencyTest
                 driver.Wait(1);
 
                 driver.TypeIntoField(password, credentials.Password + Keys.Enter);
-                driver.Wait(1);
+                driver.Wait(2);
 
                 ScenarioEventSourceProvider.EventLog.AccountLogInStop("Facebook");
                 Logger.LogWriteLine("    Completed logging into Facebook...");
@@ -99,6 +99,19 @@ namespace BrowserEfficiencyTest
                 Logger.LogWriteLine("    Facebook notification request window found! Attempting to click 'Not Now' button.");
                 cancelButton = driver.FindElementByLinkText("Not Now");
                 driver.ClickElement(cancelButton);
+
+                try
+                {
+                    // Check again for the notification window. It should be gone at this point.
+                    notificationWindow = driver.FindElementById("notification-permission-title");
+
+                    // If we get here then the notification window is still open!
+                    throw new Exception("Failed to close Facebook notification window!");
+                }
+                catch (NoSuchElementException)
+                {
+                    Logger.LogWriteLine("    Successfully closed the Facebook notification window.");
+                }
             }
             catch (NoSuchElementException)
             {
@@ -117,6 +130,7 @@ namespace BrowserEfficiencyTest
             // Once we're logged in, all we're going to do is scroll through the page
             // We're simply measuring a user looking through their news feed for a minute
             driver.Wait(1);
+            Logger.LogWriteLine("    Scroll through Facebook timeline.");
             ScenarioEventSourceProvider.EventLog.ScenarioActionStart("Scroll through timeline");
             driver.ScrollPage(10);
             ScenarioEventSourceProvider.EventLog.ScenarioActionStop("Scroll through timeline");

--- a/BrowserEfficiencyTest/packages.config
+++ b/BrowserEfficiencyTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="Selenium.Support" version="3.3.0" targetFramework="net46" />
-  <package id="Selenium.WebDriver" version="3.3.0" targetFramework="net46" />
+  <package id="Selenium.Support" version="3.13.0" targetFramework="net46" />
+  <package id="Selenium.WebDriver" version="3.13.0" targetFramework="net46" />
 </packages>

--- a/PerfProcessor/Properties/AssemblyInfo.cs
+++ b/PerfProcessor/Properties/AssemblyInfo.cs
@@ -58,4 +58,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("19.2")]
+[assembly: AssemblyVersion("20.0")]


### PR DESCRIPTION
Updated the Selenium Webdriver NuGet packages to use 3.13.0 to support changes in MicrosoftWebDriver.exe defaulting to W3C only commands.
Removed explicitly setting Edge browserName capability.
Fixed issue where SendKeys fails with a null reference exception.
Fixed issue were W3C webdriver status command does not return the webdriver version.
Added check in FacebookNewsFeedScroll for verifying the notification window was closed properly.
Updated version to 20.0
