### PR TITLE
Changed docs.microsoft.com to learn.microsoft.com

### DIFF
--- a/BrowserEfficiencyTest/Arguments.cs
+++ b/BrowserEfficiencyTest/Arguments.cs
@@ -548,7 +548,7 @@ namespace BrowserEfficiencyTest
                     case "-region":
                         // The name of the region must be specified after the -region option.
                         // The region must be defined in the ActiveRegion.xml
-                        // See https://docs.microsoft.com/en-us/windows-hardware/test/wpt/regions-of-interest for more information
+                        // See https://learn.microsoft.com/windows-hardware/test/wpt/regions-of-interest for more information
                         // on Regions of Interest.
                         argNum++;
                         if ((argNum < args.Length) && !(args[argNum].StartsWith("-")))

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -210,7 +210,7 @@ C:\unpackedExtensions
 |----|----|---- <otherExtFiles>
 ```
 #### Testing your own extension
-If you wish prepare your own extension for testing, you can follow the first half of the Microsoft Edge Extension [ManifoldJS Packaging Guide](https://docs.microsoft.com/en-us/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions) to generate an unpacked extension AppX. From there, you will need to copy the `manifest` folder that ManifoldJS generates into a folder (`C:\unpackedExtensions` for the purposes of this demo) to match the structure above. 
+If you wish prepare your own extension for testing, you can follow the first half of the Microsoft Edge Extension [ManifoldJS Packaging Guide](https://learn.microsoft.com/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions) to generate an unpacked extension AppX. From there, you will need to copy the `manifest` folder that ManifoldJS generates into a folder (`C:\unpackedExtensions` for the purposes of this demo) to match the structure above. 
 
 #### Testing an extension from the Windows Store
 If you wish to run BrowserEfficiencyTest with an extension that is available from the Windows Store, you will need to perform the following steps:


### PR DESCRIPTION
URLs update/cleanup as part of a sweep of MicrosoftEdge org repo's:
* Changed docs.microsoft.com to learn.microsoft.com and removed en-us.